### PR TITLE
add protocol quicklink to docs hero

### DIFF
--- a/web/src/app/docs/page.tsx
+++ b/web/src/app/docs/page.tsx
@@ -239,6 +239,12 @@ export default function DocsPage() {
                 Full API Reference
               </Link>
               <Link
+                href="/docs/protocol"
+                className="inline-flex h-9 items-center border border-border px-4 font-mono text-xs text-text-primary transition-colors hover:border-border-hover hover:bg-bg-secondary"
+              >
+                Protocol
+              </Link>
+              <Link
                 href="/docs/contracts"
                 className="inline-flex h-9 items-center border border-border px-4 font-mono text-xs text-text-primary transition-colors hover:border-border-hover hover:bg-bg-secondary"
               >


### PR DESCRIPTION
Adds a Protocol quicklink button to the /docs hero link row, next to Full API Reference and Protocol Reference, so the new /docs/protocol section is discoverable from the main docs landing page.