### PR TITLE
Fix docs subdomain sidebar and footer cross-host links

### DIFF
--- a/web/src/components/layout/Footer.tsx
+++ b/web/src/components/layout/Footer.tsx
@@ -1,8 +1,23 @@
 'use client';
 
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
 import { usePathname } from 'next/navigation';
 import { cn } from '@/lib/utils';
+
+// See SidebarMenu.tsx — on docs.relay44.com only /docs/* routes exist, so
+// non-docs footer links must jump to the apex.
+const DOCS_HOST = 'docs.relay44.com';
+const APEX_ORIGIN = 'https://relay44.com';
+
+function useIsDocsHost() {
+  const [isDocs, setIsDocs] = useState(false);
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    setIsDocs(window.location.hostname === DOCS_HOST);
+  }, []);
+  return isDocs;
+}
 
 const productLinks = [
   { href: '/markets', label: 'Markets' },
@@ -52,46 +67,53 @@ function FooterColumn({
 
 export function Footer() {
   const pathname = usePathname();
+  const isDocsHost = useIsDocsHost();
 
-  const linkClass = (href: string) =>
+  const linkClass = (href: string, crossHost: boolean) =>
     cn(
       'text-xs transition-colors',
-      pathname === href || (href !== '/' && pathname.startsWith(href))
+      !crossHost &&
+        (pathname === href || (href !== '/' && pathname.startsWith(href)))
         ? 'text-text-primary'
         : 'text-text-secondary hover:text-text-primary',
     );
+
+  const renderLink = ({ href, label }: { href: string; label: string }) => {
+    const crossHost = isDocsHost && !href.startsWith('/docs');
+    const resolved = crossHost ? `${APEX_ORIGIN}${href}` : href;
+    if (crossHost) {
+      return (
+        <a href={resolved} className={linkClass(href, true)}>
+          {label}
+        </a>
+      );
+    }
+    return (
+      <Link href={resolved} className={linkClass(href, false)}>
+        {label}
+      </Link>
+    );
+  };
 
   return (
     <footer className="border-t border-border bg-bg-base hidden md:block">
       <div className="max-w-[1400px] mx-auto px-4 sm:px-8 py-10">
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-8">
           <FooterColumn title="Product">
-            {productLinks.map(({ href, label }) => (
-              <li key={href}>
-                <Link href={href} className={linkClass(href)}>
-                  {label}
-                </Link>
-              </li>
+            {productLinks.map((link) => (
+              <li key={link.href}>{renderLink(link)}</li>
             ))}
           </FooterColumn>
 
           <FooterColumn title="Platform">
-            {platformLinks.map(({ href, label }) => (
-              <li key={href}>
-                <Link href={href} className={linkClass(href)}>
-                  {label}
-                </Link>
-              </li>
+            {platformLinks.map((link) => (
+              <li key={link.href}>{renderLink(link)}</li>
             ))}
           </FooterColumn>
 
           <FooterColumn title="Resources">
-            {resourceLinks.map(({ href, label }) => (
-              <li key={href}>
-                <Link href={href} className={linkClass(href)}>
-                  {label}
-                </Link>
-              </li>
+            {resourceLinks.map((link) => (
+              <li key={link.href}>{renderLink(link)}</li>
             ))}
           </FooterColumn>
 

--- a/web/src/components/layout/SidebarMenu.tsx
+++ b/web/src/components/layout/SidebarMenu.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { usePathname } from "next/navigation";
 import {
   ChevronDown,
@@ -49,6 +49,21 @@ const navLinks = [
   { href: "/docs/contracts", label: "Protocol Reference", note: "Contract addresses, ABIs, and viem snippets" },
 ];
 
+// When the app is served from the docs subdomain, only /docs/* routes exist
+// (see web/src/middleware.ts). Non-docs sidebar links must jump to the apex
+// host instead of staying on docs.relay44.com where they would 404.
+const DOCS_HOST = "docs.relay44.com";
+const APEX_ORIGIN = "https://relay44.com";
+
+function useIsDocsHost() {
+  const [isDocs, setIsDocs] = useState(false);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    setIsDocs(window.location.hostname === DOCS_HOST);
+  }, []);
+  return isDocs;
+}
+
 const externalLinks = [
   {
     href: "https://x.com/Relay44BASE",
@@ -87,6 +102,20 @@ export function SidebarMenu() {
   const { readOnly } = useRuntimeMode();
   const [open, setOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const isDocsHost = useIsDocsHost();
+
+  const resolvedNavLinks = useMemo(
+    () =>
+      navLinks.map((link) => {
+        const crossHost = isDocsHost && !link.href.startsWith("/docs");
+        return {
+          ...link,
+          resolvedHref: crossHost ? `${APEX_ORIGIN}${link.href}` : link.href,
+          crossHost,
+        };
+      }),
+    [isDocsHost],
+  );
 
   useEffect(() => {
     setOpen(false);
@@ -152,33 +181,45 @@ export function SidebarMenu() {
 
           <nav className="flex-1 overflow-y-auto px-5 py-5">
             <div className="space-y-2">
-              {navLinks.map(({ href, label, note }) => {
-                const active =
-                  pathname === href ||
-                  (href !== "/" && pathname.startsWith(href));
-                return (
-                  <Link
-                    key={href}
-                    href={href}
-                    className={cn(
-                      "block border px-4 py-3 transition-colors",
-                      active
-                        ? "border-accent bg-accent/10 text-text-primary"
-                        : "border-border text-text-secondary hover:border-border-hover hover:bg-bg-secondary hover:text-text-primary",
-                    )}
-                  >
-                    <div className="flex items-center justify-between gap-4">
-                      <span className="text-sm font-medium uppercase tracking-[0.12em]">
-                        {label}
-                      </span>
-                      <SquareDashedMousePointer className="h-4 w-4 opacity-40" />
-                    </div>
-                    <p className="mt-2 text-xs uppercase tracking-[0.14em] text-text-muted">
-                      {note}
-                    </p>
-                  </Link>
-                );
-              })}
+              {resolvedNavLinks.map(
+                ({ href, resolvedHref, crossHost, label, note }) => {
+                  const active =
+                    !crossHost &&
+                    (pathname === href ||
+                      (href !== "/" && pathname.startsWith(href)));
+                  const className = cn(
+                    "block border px-4 py-3 transition-colors",
+                    active
+                      ? "border-accent bg-accent/10 text-text-primary"
+                      : "border-border text-text-secondary hover:border-border-hover hover:bg-bg-secondary hover:text-text-primary",
+                  );
+                  const content = (
+                    <>
+                      <div className="flex items-center justify-between gap-4">
+                        <span className="text-sm font-medium uppercase tracking-[0.12em]">
+                          {label}
+                        </span>
+                        <SquareDashedMousePointer className="h-4 w-4 opacity-40" />
+                      </div>
+                      <p className="mt-2 text-xs uppercase tracking-[0.14em] text-text-muted">
+                        {note}
+                      </p>
+                    </>
+                  );
+                  if (crossHost) {
+                    return (
+                      <a key={href} href={resolvedHref} className={className}>
+                        {content}
+                      </a>
+                    );
+                  }
+                  return (
+                    <Link key={href} href={resolvedHref} className={className}>
+                      {content}
+                    </Link>
+                  );
+                },
+              )}
             </div>
 
             <div className="mt-6 border-t border-border pt-6">


### PR DESCRIPTION
## Summary

On `docs.relay44.com` the Next.js middleware (`web/src/middleware.ts`) rewrites every non-`/docs` path into `/docs/<path>`, which 404s for routes that don't live under `/docs`. The side menu and footer were emitting root-relative hrefs like `/wallet` and `/portfolio`, so clicking them kept you on the docs subdomain and died with a 404.

This fix detects the docs host client-side and rewrites non-`/docs` nav links to absolute `https://relay44.com/<path>` URLs rendered as plain anchors, triggering a full cross-host navigation back to the apex. Internal `/docs*` links (Docs, Protocol, Protocol Reference) stay as `<Link>`s and continue to work on both the apex and the docs subdomain.

No behavior change on `relay44.com` — `useIsDocsHost` returns false and everything renders as the existing internal Next `<Link>`, preserving active-route highlighting and client navigation.

## Reproduction

Before: https://docs.relay44.com/wallet → 404 (rewritten to `/docs/wallet`)
After: the "Wallet" entry in the docs sidebar navigates to https://relay44.com/wallet

## Files

- `web/src/components/layout/SidebarMenu.tsx` — `useIsDocsHost` hook + `resolvedNavLinks` with per-link `crossHost` flag; `<Link>` vs `<a>` switch in render loop.
- `web/src/components/layout/Footer.tsx` — same pattern via a local `renderLink` helper for all three footer columns.

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [ ] After deploy: click every sidebar item from `https://docs.relay44.com/docs` and confirm non-docs items jump to `relay44.com`
- [ ] Active-route highlighting still works when browsing docs on the docs subdomain
- [ ] Active-route highlighting unchanged on the apex