### PR TITLE
fix docs host cross links in tokenomics callouts

### DIFF
--- a/web/src/app/docs/contracts/page.tsx
+++ b/web/src/app/docs/contracts/page.tsx
@@ -1,6 +1,7 @@
 import { StructuredData } from '@/components/seo/StructuredData';
 import { CodeBlock } from '@/components/docs';
 import { Card } from '@/components/ui';
+import { CrossHostLink } from '@/components/layout/CrossHostLink';
 import {
   buildBreadcrumbStructuredData,
   buildPageMetadata,
@@ -302,12 +303,12 @@ export default function ContractsPage() {
           </p>
           <p className="mt-3 text-sm leading-6 text-text-secondary">
             Want to build on the protocol directly? See{' '}
-            <a
+            <CrossHostLink
               href="/tokenomics"
               className="text-text-primary underline-offset-2 hover:underline"
             >
               /tokenomics
-            </a>{' '}
+            </CrossHostLink>{' '}
             for how fees and rewards flow back to stakers, agents, and creators, or
             jump straight to the{' '}
             <a

--- a/web/src/app/docs/page.tsx
+++ b/web/src/app/docs/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import Link from "next/link";
+import { CrossHostLink } from "@/components/layout/CrossHostLink";
 import { cn } from "@/lib/utils";
 
 /* ------------------------------------------------------------------ */
@@ -250,12 +251,12 @@ export default function DocsPage() {
               >
                 Protocol Reference
               </Link>
-              <Link
+              <CrossHostLink
                 href="/tokenomics"
                 className="inline-flex h-9 items-center border border-border px-4 font-mono text-xs text-text-primary transition-colors hover:border-border-hover hover:bg-bg-secondary"
               >
                 Tokenomics
-              </Link>
+              </CrossHostLink>
             </div>
           </div>
 

--- a/web/src/components/layout/CrossHostLink.tsx
+++ b/web/src/components/layout/CrossHostLink.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+
+// On docs.relay44.com, only /docs/* routes exist (see web/src/middleware.ts).
+// Links that target non-docs routes must jump to the apex host instead of
+// staying on docs.relay44.com where they would 404.
+const DOCS_HOST = 'docs.relay44.com';
+const APEX_ORIGIN = 'https://relay44.com';
+
+function useIsDocsHost() {
+  const [isDocs, setIsDocs] = useState(false);
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    setIsDocs(window.location.hostname === DOCS_HOST);
+  }, []);
+  return isDocs;
+}
+
+interface CrossHostLinkProps {
+  href: string;
+  className?: string;
+  children: React.ReactNode;
+}
+
+/**
+ * Renders a next/link for same-host targets and a plain <a> for cross-host
+ * targets. When served from docs.relay44.com, any href that does not start
+ * with /docs is rewritten to the apex origin.
+ */
+export function CrossHostLink({ href, className, children }: CrossHostLinkProps) {
+  const isDocsHost = useIsDocsHost();
+  const crossHost = isDocsHost && !href.startsWith('/docs');
+  const resolved = crossHost ? `${APEX_ORIGIN}${href}` : href;
+
+  if (crossHost) {
+    return (
+      <a href={resolved} className={className}>
+        {children}
+      </a>
+    );
+  }
+  return (
+    <Link href={resolved} className={className}>
+      {children}
+    </Link>
+  );
+}


### PR DESCRIPTION
## Summary
Extends the docs-subdomain cross-host fix from #35 to in-page links that were still using `<Link href="/tokenomics">` on `/docs` and `/docs/contracts`. On `docs.relay44.com` these were 404ing via the middleware rewrite.

Adds a reusable `CrossHostLink` client component in `web/src/components/layout/CrossHostLink.tsx` that:
- Detects `window.location.hostname === 'docs.relay44.com'` on mount
- Renders a plain `<a href="https://relay44.com/...">` for non-`/docs` targets when on docs host
- Falls back to `next/link` otherwise

Uses the helper in:
- `web/src/app/docs/page.tsx` — Tokenomics quicklink
- `web/src/app/docs/contracts/page.tsx` — inline `/tokenomics` callout

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] CI green
- [ ] After deploy, click "Tokenomics" quicklink on https://docs.relay44.com/docs → goes to https://relay44.com/tokenomics
- [ ] Same check on https://docs.relay44.com/docs/contracts