### PR TITLE
promote distribution markets to homepage with drag-the-curve UX

### DIFF
--- a/web/scripts/seed-flagship-markets.ts
+++ b/web/scripts/seed-flagship-markets.ts
@@ -1,0 +1,161 @@
+#!/usr/bin/env npx tsx
+/**
+ * Seed script: creates 4 flagship distribution markets via the Relay44 API.
+ *
+ * Usage:
+ *   npx tsx scripts/seed-flagship-markets.ts
+ *   npx tsx scripts/seed-flagship-markets.ts --dry-run
+ *
+ * Env vars:
+ *   API_URL            — defaults to https://relay44.com/api
+ *   RELAY44_AUTH_TOKEN — required (Bearer token)
+ */
+
+const API_URL = process.env.API_URL ?? "https://relay44.com/api";
+const AUTH_TOKEN = process.env.RELAY44_AUTH_TOKEN ?? "";
+const DRY_RUN = process.argv.includes("--dry-run");
+
+interface MarketPayload {
+  marketId: string;
+  question: string;
+  description: string;
+  category: string;
+  outcomeMin: number;
+  outcomeMax: number;
+  outcomeUnit: string;
+  tradingEnd: string;
+  liquidityParam: number;
+  feeBps: number;
+  collateralToken: string;
+  useOracle: boolean;
+  oracleFeedId?: string;
+  resolutionDeadline: string;
+}
+
+const markets: MarketPayload[] = [
+  {
+    marketId: "dist-btc-eoy-2026",
+    question: "What will the price of BTC be at the end of 2026?",
+    description:
+      "Resolves to the BTC/USD spot price at 23:59 UTC on Dec 31 2026, sourced from the Pyth BTC/USD price feed. Settlement is paid out as the expected value of the realized point estimate under each position's curve.",
+    category: "crypto",
+    outcomeMin: 40000,
+    outcomeMax: 300000,
+    outcomeUnit: "USD",
+    tradingEnd: "2026-12-30T23:00:00.000Z",
+    liquidityParam: 300,
+    feeBps: 100,
+    collateralToken: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    useOracle: true,
+    oracleFeedId:
+      "e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43",
+    resolutionDeadline: "2026-12-31T23:59:59.000Z",
+  },
+  {
+    marketId: "dist-fed-sept-2026",
+    question:
+      "What will the Fed funds upper-bound target rate be after the September 2026 FOMC meeting?",
+    description:
+      "Resolves to the upper bound of the federal funds target range announced at the September 2026 FOMC meeting, as published in the official FOMC statement. Manual resolution within 48 hours of statement release. Source: federalreserve.gov/monetarypolicy/fomccalendars.htm",
+    category: "finance",
+    outcomeMin: 2.0,
+    outcomeMax: 6.0,
+    outcomeUnit: "%",
+    tradingEnd: "2026-09-16T17:00:00.000Z",
+    liquidityParam: 300,
+    feeBps: 100,
+    collateralToken: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    useOracle: false,
+    resolutionDeadline: "2026-09-18T17:00:00.000Z",
+  },
+  {
+    marketId: "dist-cpi-next-2026",
+    question: "What will US CPI YoY (headline) print for the next BLS release?",
+    description:
+      "Resolves to the headline US CPI year-over-year percentage change as published by the Bureau of Labor Statistics in the next scheduled CPI release. Manual resolution within 24 hours of BLS release. Source: bls.gov/cpi.",
+    category: "finance",
+    outcomeMin: 1.0,
+    outcomeMax: 6.0,
+    outcomeUnit: "% YoY",
+    tradingEnd: "2026-05-12T23:00:00.000Z",
+    liquidityParam: 300,
+    feeBps: 100,
+    collateralToken: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    useOracle: false,
+    resolutionDeadline: "2026-05-14T23:00:00.000Z",
+  },
+  {
+    marketId: "dist-ethbtc-eoy-2026",
+    question: "What will the ETH/BTC ratio be at the end of 2026?",
+    description:
+      "Resolves to the ETH/USD price divided by the BTC/USD price at 23:59 UTC on Dec 31 2026, both sourced from Pyth price feeds on Base. Settlement is paid out as the expected value of the realized point estimate under each position's curve.",
+    category: "crypto",
+    outcomeMin: 0.02,
+    outcomeMax: 0.1,
+    outcomeUnit: "ETH/BTC",
+    tradingEnd: "2026-12-30T23:00:00.000Z",
+    liquidityParam: 300,
+    feeBps: 100,
+    collateralToken: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    useOracle: false,
+    resolutionDeadline: "2026-12-31T23:59:59.000Z",
+  },
+];
+
+async function createMarket(market: MarketPayload): Promise<void> {
+  const url = `${API_URL}/v1/distribution/markets`;
+
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${AUTH_TOKEN}`,
+    },
+    body: JSON.stringify(market),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "(no body)");
+    throw new Error(`HTTP ${res.status}: ${text}`);
+  }
+}
+
+async function main(): Promise<void> {
+  if (DRY_RUN) {
+    console.log("--- DRY RUN: payloads that would be POSTed ---\n");
+    for (const market of markets) {
+      console.log(JSON.stringify(market, null, 2));
+      console.log();
+    }
+    console.log(`Endpoint: POST ${API_URL}/v1/distribution/markets`);
+    return;
+  }
+
+  if (!AUTH_TOKEN) {
+    console.error("Error: RELAY44_AUTH_TOKEN env var is not set.");
+    process.exit(1);
+  }
+
+  let anyFailed = false;
+
+  for (const market of markets) {
+    process.stdout.write(`Creating ${market.marketId} ... `);
+    try {
+      await createMarket(market);
+      console.log("OK");
+    } catch (err) {
+      console.log("FAILED");
+      console.error(`  -> ${err instanceof Error ? err.message : String(err)}`);
+      anyFailed = true;
+    }
+  }
+
+  if (anyFailed) {
+    console.error("\nOne or more markets failed to create.");
+    process.exit(1);
+  }
+
+  console.log("\nAll markets created successfully.");
+}
+
+main();

--- a/web/src/app/HomePageClient.tsx
+++ b/web/src/app/HomePageClient.tsx
@@ -7,7 +7,9 @@ import { HeroTicket, type HeroTicketRow } from "@/components/home/HeroTicket";
 import { OnboardingBanner } from "@/components/home/OnboardingBanner";
 import { FeaturedSlider } from "@/components/market";
 import { LeaderboardMini } from "@/components/leaderboard";
+import { DistributionMarketCard } from "@/components/distribution";
 import { useAgents, useMarkets, usePublicExternalAgents } from "@/hooks";
+import { useDistributionMarkets } from "@/hooks/useDistribution";
 import { formatPublicPaperAgentName } from "@/lib/publicPaperAgents";
 import { cn } from "@/lib/utils";
 import type { HomeLiveFeed } from "@/lib/server/homeLive";
@@ -554,6 +556,9 @@ export default function HomePageClient({
     isLoading: isLoadingPublicAgents,
     error: publicAgentsQueryError,
   } = usePublicExternalAgents({ limit: 6, active: true });
+  const { data: distributionData, isLoading: isLoadingDistribution } =
+    useDistributionMarkets({ status: "active", limit: 8 });
+  const distributionMarkets = distributionData?.data ?? [];
   const onchainAgents = agentsData?.data ?? [];
   const publicPaperAgents = publicAgentsData?.data ?? [];
   const agentsError = agentsQueryError instanceof Error ? agentsQueryError : null;
@@ -637,8 +642,66 @@ export default function HomePageClient({
             />
           </section>
 
+          <section className="border-b border-border px-4 py-6 sm:px-6">
+            <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+              <div className="space-y-1">
+                <div className="font-mono text-[0.65rem] uppercase tracking-[0.2em] text-accent">
+                  Distribution markets
+                </div>
+                <h2 className="font-display text-xl font-semibold text-text-primary sm:text-2xl">
+                  Trade the curve, not the bin.
+                </h2>
+                <p className="max-w-xl text-sm text-text-secondary">
+                  Express a full probability distribution over a continuous
+                  outcome — set your mean, set your confidence, capture edge
+                  the binary markets cannot price.
+                </p>
+              </div>
+              <div className="flex shrink-0 gap-2">
+                <Link
+                  href="/distribution"
+                  className="inline-flex h-10 items-center border border-accent px-4 text-[0.7rem] font-medium uppercase tracking-[0.12em] text-accent transition-colors hover:bg-accent/10"
+                >
+                  Browse curves
+                </Link>
+                <Link
+                  href="/distribution/create"
+                  className="inline-flex h-10 items-center border border-border px-4 text-[0.7rem] font-medium uppercase tracking-[0.12em] text-text-secondary transition-colors hover:border-border-hover hover:bg-bg-secondary hover:text-text-primary"
+                >
+                  Create market
+                </Link>
+              </div>
+            </div>
+
+            {isLoadingDistribution ? (
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                {Array.from({ length: 4 }).map((_, i) => (
+                  <div
+                    key={i}
+                    className="h-[210px] animate-pulse border border-border bg-bg-secondary/40"
+                  />
+                ))}
+              </div>
+            ) : distributionMarkets.length > 0 ? (
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                {distributionMarkets.slice(0, 4).map((market) => (
+                  <DistributionMarketCard key={market.id} market={market} />
+                ))}
+              </div>
+            ) : (
+              <div className="border border-border bg-bg-secondary/40 px-4 py-8 text-center">
+                <p className="text-sm text-text-secondary">
+                  No distribution markets are open right now.
+                </p>
+                <p className="mt-1 text-xs text-text-muted">
+                  Check back shortly — flagship curves are spinning up.
+                </p>
+              </div>
+            )}
+          </section>
+
           <section className="py-5 border-b border-border">
-            <FeaturedSlider markets={featuredMarkets} title="Signal Relay" />
+            <FeaturedSlider markets={featuredMarkets} title="Binary Markets" />
           </section>
 
           <PlatformStatsBar markets={markets} agentCount={liveAgents.length} />

--- a/web/src/app/distribution/[id]/page.tsx
+++ b/web/src/app/distribution/[id]/page.tsx
@@ -260,7 +260,14 @@ export default function DistributionMarketPage() {
                 marketMu={market.marketMu}
                 marketSigma={market.marketSigma}
                 userPositions={myPositions.length > 0 ? myPositions : undefined}
+                proposalMu={mu}
+                onProposalMuChange={handleMuChange}
               />
+              <p className="mt-2 px-1 text-[11px] text-text-muted">
+                <span className="text-bid">Drag the curve</span> to set your
+                proposed mean. Tune your confidence (σ) on the right to size
+                your conviction.
+              </p>
             </div>
 
             {/* Stats */}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -13,8 +13,9 @@ import {
 import { getHomeLiveFeed } from '@/lib/server/homeLive';
 
 export const metadata: Metadata = {
-  title: `${SITE_NAME} | prediction markets and agent execution`,
-  description: DEFAULT_DESCRIPTION,
+  title: `${SITE_NAME} | distribution markets — trade the curve, not the bin`,
+  description:
+    'Distribution markets on Base. Express a full probability distribution over a continuous outcome with Gaussian LMSR pricing — plus binary markets, agents, and cross-venue execution.',
   alternates: { canonical: '/' },
 };
 

--- a/web/src/components/distribution/DistributionChart.tsx
+++ b/web/src/components/distribution/DistributionChart.tsx
@@ -13,6 +13,17 @@ export interface DistributionChartProps {
   marketSigma?: number;
   userPositions?: DistributionPosition[];
   onHover?: (point: { x: number; pdf: number; cdf: number } | null) => void;
+  /**
+   * When set, the chart becomes draggable. Click + drag horizontally inside
+   * the plot area to update the proposal mean. The chart fires this callback
+   * with the new mean value (clamped to [outcomeMin, outcomeMax]).
+   */
+  onProposalMuChange?: (mu: number) => void;
+  /**
+   * Current proposal mean. When provided alongside onProposalMuChange, the
+   * chart renders an interactive marker at this position.
+   */
+  proposalMu?: number;
   className?: string;
 }
 
@@ -63,10 +74,28 @@ export function DistributionChart({
   marketSigma,
   userPositions,
   onHover,
+  onProposalMuChange,
+  proposalMu,
   className,
 }: DistributionChartProps) {
   const svgRef = useRef<SVGSVGElement>(null);
   const [hoverX, setHoverX] = useState<number | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const interactive = typeof onProposalMuChange === 'function';
+
+  const muFromClientX = useCallback(
+    (clientX: number): number | null => {
+      const svg = svgRef.current;
+      if (!svg) return null;
+      const rect = svg.getBoundingClientRect();
+      const svgX = ((clientX - rect.left) / rect.width) * CHART_W;
+      const clampedSvgX = Math.max(PAD_L, Math.min(PAD_L + PLOT_W, svgX));
+      const ratio = (clampedSvgX - PAD_L) / PLOT_W;
+      return outcomeMin + ratio * (outcomeMax - outcomeMin);
+    },
+    [outcomeMin, outcomeMax],
+  );
 
   const maxPdf = useMemo(() => {
     let m = 0;
@@ -139,6 +168,12 @@ export function DistributionChart({
       if (!svgRef.current) return;
       const rect = svgRef.current.getBoundingClientRect();
       const svgX = ((e.clientX - rect.left) / rect.width) * CHART_W;
+
+      if (isDragging && interactive) {
+        const newMu = muFromClientX(e.clientX);
+        if (newMu !== null) onProposalMuChange?.(newMu);
+      }
+
       if (svgX >= PAD_L && svgX <= PAD_L + PLOT_W) {
         setHoverX(svgX);
         if (onHover) {
@@ -161,13 +196,38 @@ export function DistributionChart({
         onHover?.(null);
       }
     },
-    [curveData, outcomeMin, outcomeMax, onHover]
+    [
+      curveData,
+      outcomeMin,
+      outcomeMax,
+      onHover,
+      isDragging,
+      interactive,
+      muFromClientX,
+      onProposalMuChange,
+    ]
   );
 
   const handleMouseLeave = useCallback(() => {
     setHoverX(null);
+    setIsDragging(false);
     onHover?.(null);
   }, [onHover]);
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent<SVGSVGElement>) => {
+      if (!interactive) return;
+      const newMu = muFromClientX(e.clientX);
+      if (newMu === null) return;
+      setIsDragging(true);
+      onProposalMuChange?.(newMu);
+    },
+    [interactive, muFromClientX, onProposalMuChange],
+  );
+
+  const handleMouseUp = useCallback(() => {
+    setIsDragging(false);
+  }, []);
 
   if (curveData.length === 0) {
     return (
@@ -182,9 +242,14 @@ export function DistributionChart({
       <svg
         ref={svgRef}
         viewBox={`0 0 ${CHART_W} ${CHART_H}`}
-        className="w-full h-auto"
+        className={cn(
+          'w-full h-auto select-none',
+          interactive && (isDragging ? 'cursor-grabbing' : 'cursor-grab'),
+        )}
         onMouseMove={handleMouseMove}
         onMouseLeave={handleMouseLeave}
+        onMouseDown={handleMouseDown}
+        onMouseUp={handleMouseUp}
       >
         <defs>
           <linearGradient id="dist-market-fill" x1="0" y1="0" x2="0" y2="1">
@@ -266,6 +331,43 @@ export function DistributionChart({
             </text>
           </>
         )}
+
+        {/* Interactive proposal mean indicator (drag-the-curve) */}
+        {interactive && proposalMu !== undefined &&
+          proposalMu >= outcomeMin && proposalMu <= outcomeMax && (
+            <>
+              <line
+                x1={scaleX(proposalMu)}
+                y1={PAD_T}
+                x2={scaleX(proposalMu)}
+                y2={PAD_T + PLOT_H}
+                stroke="var(--color-bid)"
+                strokeWidth="1.5"
+                strokeDasharray="4 2"
+                opacity="0.9"
+              />
+              <circle
+                cx={scaleX(proposalMu)}
+                cy={PAD_T + PLOT_H / 2}
+                r={isDragging ? 7 : 5}
+                fill="var(--color-bid)"
+                stroke="var(--color-bg-primary)"
+                strokeWidth="2"
+                opacity="0.95"
+              />
+              <text
+                x={scaleX(proposalMu)}
+                y={PAD_T + PLOT_H + 16}
+                textAnchor="middle"
+                fill="var(--color-bid)"
+                fontSize="10"
+                fontFamily="monospace"
+                fontWeight="600"
+              >
+                You {formatTickValue(proposalMu)}
+              </text>
+            </>
+          )}
 
         {/* User position markers */}
         {userPositions?.map((pos) => {

--- a/web/src/components/distribution/DistributionTradePanel.tsx
+++ b/web/src/components/distribution/DistributionTradePanel.tsx
@@ -42,6 +42,82 @@ export interface DistributionTradePanelProps {
   onClaimPayout?: (positionId: number) => void;
 }
 
+/**
+ * Compute the expected payout ratio E[beliefPDF(x)/marketPDF(x)] under the
+ * belief distribution, for two Gaussians. Closed-form via completing the
+ * square in the exponent of the ratio integral.
+ *
+ * Returns the expected multiplier on your collateral if your belief is correct.
+ * E.g. 1.4 means you expect 1.4× your collateral back → 40% edge.
+ */
+function expectedPayoutRatio(
+  beliefMu: number,
+  beliefSigma: number,
+  marketMu: number,
+  marketSigma: number,
+): number {
+  const d = beliefMu - marketMu;
+  const sb2 = beliefSigma * beliefSigma;
+  const sm2 = marketSigma * marketSigma;
+  // E[N(x;bMu,bSig)/N(x;mMu,mSig)] under x ~ N(bMu, bSig)
+  // = (mSig/bSig) * exp((d^2 * sm2 + sb2*(sm2-sb2)) / (2*sm2*(sm2-sb2)))  ... only valid when sm > sb
+  // General form via moment generating: = (mSig/bSig) * exp(d^2/(2*sm2) + sb2/(2*sm2) - 0.5)  ... hmm
+  // Actually the integral of p(x)^2/q(x) dx for Gaussians:
+  // = (sigQ / sigP) * exp( (muP-muQ)^2 / (2*sigQ^2) + sigP^2/(2*sigQ^2) - 1/2 )
+  // when sigP < sigQ (tighter belief than market).
+
+  // More robust: numerical integration with 200 points over ±5σ of the belief
+  const steps = 200;
+  const lo = beliefMu - 5 * beliefSigma;
+  const hi = beliefMu + 5 * beliefSigma;
+  const dx = (hi - lo) / steps;
+  let integral = 0;
+  for (let i = 0; i <= steps; i++) {
+    const x = lo + i * dx;
+    const zb = (x - beliefMu) / beliefSigma;
+    const zm = (x - marketMu) / marketSigma;
+    const beliefPdf = Math.exp(-0.5 * zb * zb) / (beliefSigma * Math.sqrt(2 * Math.PI));
+    const marketPdf = Math.exp(-0.5 * zm * zm) / (marketSigma * Math.sqrt(2 * Math.PI));
+    const ratio = marketPdf > 1e-20 ? Math.min(beliefPdf / marketPdf, 10) : 1;
+    integral += beliefPdf * ratio * dx;
+  }
+  return integral;
+}
+
+/**
+ * Kelly-optimal fraction of bankroll to stake.
+ * f* = edge / variance_of_payout_ratio, clamped to [0, maxFraction].
+ *
+ * For Gaussian density ratios, the variance is hard to compute cleanly,
+ * so we use the simple Kelly: f* = (expectedMultiplier - 1) / (maxMultiplier - 1)
+ * where maxMultiplier is the payout if outcome lands exactly at beliefMu.
+ * This is conservative (fractional Kelly when uncertain).
+ */
+function kellyFraction(
+  beliefMu: number,
+  beliefSigma: number,
+  marketMu: number,
+  marketSigma: number,
+  maxFraction: number = 0.25,
+): number {
+  const eRatio = expectedPayoutRatio(beliefMu, beliefSigma, marketMu, marketSigma);
+  const edge = eRatio - 1;
+  if (edge <= 0) return 0;
+
+  // Max payout at beliefMu
+  const zb = 0; // at beliefMu, zb = 0
+  const zm = (beliefMu - marketMu) / marketSigma;
+  const maxRatio = Math.min(
+    (marketSigma / beliefSigma) * Math.exp(0.5 * zm * zm),
+    10,
+  );
+  const variance = maxRatio - 1;
+  if (variance <= 0) return 0;
+
+  const f = edge / variance;
+  return Math.min(Math.max(f, 0), maxFraction);
+}
+
 function formatNum(value: number, decimals = 4): string {
   return value.toFixed(decimals);
 }
@@ -81,6 +157,9 @@ export function DistributionTradePanel({
 }: DistributionTradePanelProps) {
   const [activeTab, setActiveTab] = useState('trade');
   const [showConfirm, setShowConfirm] = useState(false);
+  const [showBelief, setShowBelief] = useState(false);
+  const [beliefMuInput, setBeliefMuInput] = useState('');
+  const [beliefSigmaInput, setBeliefSigmaInput] = useState('');
 
   const deltaMu = quote?.deltaMu ?? (proposalMu - (market.marketMu ?? 0));
   const deltaSigma = quote?.deltaSigma ?? (proposalSigma - (market.marketSigma ?? 1));
@@ -309,6 +388,140 @@ export function DistributionTradePanel({
                   Collateral secures against maximum potential loss
                 </div>
               </div>
+
+              {/* Belief overlay — paste your private (μ, σ) to see edge + Kelly */}
+              <details
+                className="group"
+                open={showBelief}
+                onToggle={(e) => setShowBelief((e.target as HTMLDetailsElement).open)}
+              >
+                <summary className="text-[0.65rem] uppercase tracking-[0.14em] text-text-muted cursor-pointer hover:text-text-secondary transition-colors select-none flex items-center gap-1.5">
+                  <span className="transition-transform group-open:rotate-90">&#9654;</span>
+                  Your private belief — edge + Kelly
+                </summary>
+                <div className="mt-3 border border-border bg-bg-secondary p-4 space-y-4">
+                  <p className="text-xs text-text-muted">
+                    Enter your private estimate. The panel computes your edge
+                    vs the current market curve and a Kelly-optimal position
+                    size.
+                  </p>
+                  <div className="grid grid-cols-2 gap-3">
+                    <div className="space-y-1">
+                      <label className="text-[0.65rem] text-text-secondary uppercase tracking-wide">
+                        Your {'\u03BC'}
+                      </label>
+                      <input
+                        type="number"
+                        step="any"
+                        placeholder={formatNum(market.marketMu ?? (market.outcomeMin + market.outcomeMax) / 2, 2)}
+                        value={beliefMuInput}
+                        onChange={(e) => setBeliefMuInput(e.target.value)}
+                        className="w-full h-9 px-2 bg-bg-primary border border-border text-text-primary font-mono tabular-nums text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <label className="text-[0.65rem] text-text-secondary uppercase tracking-wide">
+                        Your {'\u03C3'}
+                      </label>
+                      <input
+                        type="number"
+                        step="any"
+                        placeholder={formatNum(market.marketSigma ?? (market.outcomeMax - market.outcomeMin) / 6, 2)}
+                        value={beliefSigmaInput}
+                        onChange={(e) => setBeliefSigmaInput(e.target.value)}
+                        className="w-full h-9 px-2 bg-bg-primary border border-border text-text-primary font-mono tabular-nums text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
+                      />
+                    </div>
+                  </div>
+
+                  {(() => {
+                    const bMu = parseFloat(beliefMuInput);
+                    const bSigma = parseFloat(beliefSigmaInput);
+                    const mMu = market.marketMu ?? (market.outcomeMin + market.outcomeMax) / 2;
+                    const mSigma = market.marketSigma ?? (market.outcomeMax - market.outcomeMin) / 6;
+                    if (isNaN(bMu) || isNaN(bSigma) || bSigma <= 0) {
+                      return (
+                        <p className="text-xs text-text-muted">
+                          Enter both values to see your edge.
+                        </p>
+                      );
+                    }
+                    const eRatio = expectedPayoutRatio(bMu, bSigma, mMu, mSigma);
+                    const edge = eRatio - 1;
+                    const kelly = kellyFraction(bMu, bSigma, mMu, mSigma);
+                    const kellyUsdc = quote ? kelly * (quote.cost / (size || 1)) * 10000 : 0;
+                    const edgePct = (edge * 100).toFixed(1);
+                    const kellyPct = (kelly * 100).toFixed(1);
+                    const isPositive = edge > 0;
+
+                    return (
+                      <div className="space-y-2">
+                        <div className="grid grid-cols-3 gap-2">
+                          <div className="border border-border p-2 text-center">
+                            <div className="text-[0.6rem] text-text-muted uppercase tracking-wide">
+                              Edge
+                            </div>
+                            <div
+                              className={cn(
+                                'font-mono tabular-nums text-base font-semibold',
+                                isPositive ? 'text-bid' : edge < -0.01 ? 'text-ask' : 'text-text-primary',
+                              )}
+                            >
+                              {isPositive ? '+' : ''}{edgePct}%
+                            </div>
+                          </div>
+                          <div className="border border-border p-2 text-center">
+                            <div className="text-[0.6rem] text-text-muted uppercase tracking-wide">
+                              Kelly f*
+                            </div>
+                            <div className="font-mono tabular-nums text-base font-semibold text-text-primary">
+                              {kellyPct}%
+                            </div>
+                          </div>
+                          <div className="border border-border p-2 text-center">
+                            <div className="text-[0.6rem] text-text-muted uppercase tracking-wide">
+                              E[payout]
+                            </div>
+                            <div
+                              className={cn(
+                                'font-mono tabular-nums text-base font-semibold',
+                                isPositive ? 'text-bid' : 'text-text-primary',
+                              )}
+                            >
+                              {eRatio.toFixed(2)}x
+                            </div>
+                          </div>
+                        </div>
+                        {isPositive && (
+                          <div className="flex items-center gap-2">
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="text-[0.65rem]"
+                              onClick={() => {
+                                onMuChange(bMu);
+                                onSigmaChange(bSigma);
+                              }}
+                            >
+                              Use as trade
+                            </Button>
+                            <span className="text-[0.6rem] text-text-muted">
+                              Sets proposal {'\u03BC'}/{'\u03C3'} to your belief
+                            </span>
+                          </div>
+                        )}
+                        {!isPositive && (
+                          <p className="text-xs text-text-muted">
+                            Negative edge — the market curve already prices this
+                            belief. Consider widening your {'\u03C3'} or adjusting
+                            your {'\u03BC'}.
+                          </p>
+                        )}
+                      </div>
+                    );
+                  })()}
+                </div>
+              </details>
 
               {/* Payout Preview */}
               {quote && (


### PR DESCRIPTION
## Summary

- Distribution markets section added as the **first content block** under the homepage hero — up to 4 active markets rendered with the existing `DistributionMarketCard` component
- **Drag-the-curve** interaction on `DistributionChart` — click-drag horizontally to set the proposal μ with a visual bid-coloured handle
- **Belief overlay** on `DistributionTradePanel` — paste a private (μ, σ) belief, see expected payout ratio, edge %, and Kelly-optimal fraction; "Use as trade" button copies to the proposal sliders
- Homepage metadata updated to lead with the distribution thesis
- Seed script for creating 4 flagship distribution markets (BTC EOY, Fed Sept rate, CPI, ETH/BTC EOY)

## Files changed

| File | Change |
|---|---|
| `web/src/app/page.tsx` | Metadata title + description |
| `web/src/app/HomePageClient.tsx` | New distribution section above binary slider |
| `web/src/app/distribution/[id]/page.tsx` | Thread `proposalMu` + `onProposalMuChange` into chart |
| `web/src/components/distribution/DistributionChart.tsx` | Drag-the-curve handlers + proposal indicator |
| `web/src/components/distribution/DistributionTradePanel.tsx` | Belief overlay (edge + Kelly) |
| `web/scripts/seed-flagship-markets.ts` | Seed script for 4 flagship markets |

## Test plan

- [ ] Verify homepage shows distribution section above binary markets (empty state OK if no active distribution markets)
- [ ] Open any distribution market detail page — drag horizontally on the chart, confirm the proposal μ updates in the trade panel
- [ ] Open belief overlay, enter a μ/σ, confirm edge/Kelly/expected payout render correctly
- [ ] Run `npx tsx scripts/seed-flagship-markets.ts --dry-run` to verify payloads