### PR TITLE
agent lifecycle: durable state + intent log

### DIFF
--- a/app/src/services/managed_agent_lifecycle.rs
+++ b/app/src/services/managed_agent_lifecycle.rs
@@ -1,0 +1,559 @@
+//! Managed agent lifecycle: durable state machine + pre-commit intent log.
+//!
+//! A managed agent's `lifecycle_state` is distinct from the user-facing
+//! `status`. `status` expresses user intent (active / stopped / paused);
+//! `lifecycle_state` expresses where the runtime actually is (initializing,
+//! active, paused, liquidating, settled, failed). The runner drives
+//! transitions, users drive status.
+//!
+//! Every side-effect (open_position, close_position, later post_order /
+//! cancel_order) is preceded by an intent row in `managed_agent_intents`
+//! with state='pending'. On success the row is flipped to 'confirmed'. On
+//! process restart, `recover_unresolved_intents` reconciles any pending rows
+//! by checking whether the side-effect actually landed (position exists,
+//! order on venue, etc.) and marks them confirmed or abandoned — never
+//! re-executed blindly.
+//!
+//! Redis mirrors the hot path (checkpoint blob, pending intents hash, active
+//! set) for fast startup scans and observability, but Postgres is
+//! authoritative. Redis outages log-and-continue.
+
+use chrono::{DateTime, Utc};
+use log::{debug, warn};
+use serde::{Deserialize, Serialize};
+use sqlx::{PgPool, Row};
+use std::fmt;
+
+use crate::services::RedisService;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LifecycleState {
+    Initializing,
+    Active,
+    Paused,
+    Liquidating,
+    Settled,
+    Failed,
+}
+
+impl LifecycleState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Initializing => "initializing",
+            Self::Active => "active",
+            Self::Paused => "paused",
+            Self::Liquidating => "liquidating",
+            Self::Settled => "settled",
+            Self::Failed => "failed",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        Some(match s {
+            "initializing" => Self::Initializing,
+            "active" => Self::Active,
+            "paused" => Self::Paused,
+            "liquidating" => Self::Liquidating,
+            "settled" => Self::Settled,
+            "failed" => Self::Failed,
+            _ => return None,
+        })
+    }
+
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Settled | Self::Failed)
+    }
+
+    /// Whether the runner should pick this agent up for strategy evaluation.
+    pub fn is_runnable(self) -> bool {
+        matches!(self, Self::Active | Self::Liquidating)
+    }
+
+    fn can_transition_to(self, next: LifecycleState) -> bool {
+        use LifecycleState::*;
+        match (self, next) {
+            (Initializing, Active | Failed | Paused) => true,
+            (Active, Paused | Liquidating | Settled) => true,
+            (Paused, Active | Liquidating | Settled) => true,
+            (Liquidating, Settled) => true,
+            (Settled | Failed, _) => false,
+            (a, b) if a == b => true,
+            _ => false,
+        }
+    }
+}
+
+impl fmt::Display for LifecycleState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IntentKind {
+    OpenPosition,
+    ClosePosition,
+    PostOrder,
+    CancelOrder,
+}
+
+impl IntentKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::OpenPosition => "open_position",
+            Self::ClosePosition => "close_position",
+            Self::PostOrder => "post_order",
+            Self::CancelOrder => "cancel_order",
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct OpenPositionPayload {
+    pub provider: String,
+    pub market_slug: String,
+    pub outcome: String,
+    pub side: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ClosePositionPayload {
+    pub position_id: i64,
+    pub market_slug: String,
+    pub outcome: String,
+    pub side: String,
+}
+
+/// Handle returned by `log_intent`. Must be passed to `confirm_intent` on
+/// success — otherwise the intent stays pending and is reconciled on restart.
+#[must_use = "intents must be confirmed or abandoned"]
+#[derive(Debug, Clone, Copy)]
+pub struct IntentHandle {
+    pub agent_id_key: u64,
+    pub seq: i64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CheckpointBlob {
+    pub lifecycle_state: String,
+    pub seq: i64,
+    pub last_tick_at: DateTime<Utc>,
+    pub pnl_usdc: f64,
+    pub open_position_count: i64,
+    pub version: u32,
+}
+
+/// Transition an agent to a new lifecycle state. DB is authoritative; Redis
+/// mirror updates are best-effort. Invalid transitions return an error
+/// without touching either store.
+pub async fn set_lifecycle_state(
+    pool: &PgPool,
+    redis: &RedisService,
+    agent_id: &str,
+    next: LifecycleState,
+    reason: Option<&str>,
+) -> Result<(), String> {
+    let current: Option<String> =
+        sqlx::query_scalar("SELECT lifecycle_state FROM managed_agents WHERE id = $1 FOR UPDATE")
+            .bind(agent_id)
+            .fetch_optional(pool)
+            .await
+            .map_err(|e| e.to_string())?;
+
+    let current = current.ok_or_else(|| format!("agent {} not found", agent_id))?;
+    let current_state = LifecycleState::parse(&current)
+        .ok_or_else(|| format!("agent {} has unknown lifecycle_state={}", agent_id, current))?;
+
+    if current_state == next {
+        return Ok(());
+    }
+
+    if !current_state.can_transition_to(next) {
+        return Err(format!(
+            "invalid lifecycle transition {} → {} for agent {}",
+            current_state, next, agent_id
+        ));
+    }
+
+    sqlx::query(
+        "UPDATE managed_agents \
+         SET lifecycle_state = $1, lifecycle_updated_at = NOW(), \
+             failure_reason = $2, updated_at = NOW() \
+         WHERE id = $3",
+    )
+    .bind(next.as_str())
+    .bind(reason)
+    .bind(agent_id)
+    .execute(pool)
+    .await
+    .map_err(|e| e.to_string())?;
+
+    if next.is_runnable() {
+        if let Err(e) = redis.agent_active_mark(agent_id).await {
+            debug!("redis agent_active_mark {}: {}", agent_id, e);
+        }
+    } else if let Err(e) = redis.agent_active_unmark(agent_id).await {
+        debug!("redis agent_active_unmark {}: {}", agent_id, e);
+    }
+
+    Ok(())
+}
+
+/// Record a pending intent and return a handle. Allocates the next sequence
+/// number in the same transaction as the insert so seq is strictly monotonic
+/// per agent even under concurrent ticks (guarded by row-level lock).
+pub async fn log_intent(
+    pool: &PgPool,
+    redis: &RedisService,
+    agent_id: &str,
+    kind: IntentKind,
+    payload: &serde_json::Value,
+) -> Result<IntentHandle, String> {
+    let mut tx = pool.begin().await.map_err(|e| e.to_string())?;
+
+    let seq: i64 = sqlx::query_scalar(
+        "UPDATE managed_agents \
+         SET last_checkpoint_seq = last_checkpoint_seq + 1, \
+             last_checkpoint_at = NOW() \
+         WHERE id = $1 \
+         RETURNING last_checkpoint_seq",
+    )
+    .bind(agent_id)
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(|e| e.to_string())?;
+
+    sqlx::query(
+        "INSERT INTO managed_agent_intents (agent_id, seq, kind, payload, state) \
+         VALUES ($1, $2, $3, $4::jsonb, 'pending')",
+    )
+    .bind(agent_id)
+    .bind(seq)
+    .bind(kind.as_str())
+    .bind(payload)
+    .execute(&mut *tx)
+    .await
+    .map_err(|e| e.to_string())?;
+
+    tx.commit().await.map_err(|e| e.to_string())?;
+
+    if let Err(e) = redis
+        .agent_intent_log(agent_id, seq, &payload.to_string())
+        .await
+    {
+        debug!("redis agent_intent_log {}: {}", agent_id, e);
+    }
+
+    Ok(IntentHandle {
+        agent_id_key: fxhash(agent_id),
+        seq,
+    })
+}
+
+pub async fn confirm_intent(
+    pool: &PgPool,
+    redis: &RedisService,
+    agent_id: &str,
+    handle: IntentHandle,
+) -> Result<(), String> {
+    sqlx::query(
+        "UPDATE managed_agent_intents \
+         SET state = 'confirmed', resolved_at = NOW() \
+         WHERE agent_id = $1 AND seq = $2 AND state = 'pending'",
+    )
+    .bind(agent_id)
+    .bind(handle.seq)
+    .execute(pool)
+    .await
+    .map_err(|e| e.to_string())?;
+
+    if let Err(e) = redis.agent_intent_clear(agent_id, handle.seq).await {
+        debug!("redis agent_intent_clear {}: {}", agent_id, e);
+    }
+
+    Ok(())
+}
+
+pub async fn abandon_intent(
+    pool: &PgPool,
+    redis: &RedisService,
+    agent_id: &str,
+    handle: IntentHandle,
+    note: &str,
+) -> Result<(), String> {
+    sqlx::query(
+        "UPDATE managed_agent_intents \
+         SET state = 'abandoned', resolved_at = NOW(), resolution_note = $3 \
+         WHERE agent_id = $1 AND seq = $2 AND state = 'pending'",
+    )
+    .bind(agent_id)
+    .bind(handle.seq)
+    .bind(note)
+    .execute(pool)
+    .await
+    .map_err(|e| e.to_string())?;
+
+    if let Err(e) = redis.agent_intent_clear(agent_id, handle.seq).await {
+        debug!("redis agent_intent_clear {}: {}", agent_id, e);
+    }
+
+    Ok(())
+}
+
+/// Write a checkpoint blob mirror to Redis. DB columns `last_checkpoint_at`
+/// and `last_checkpoint_seq` are maintained by `log_intent`; this is the
+/// observability mirror.
+pub async fn write_checkpoint_mirror(redis: &RedisService, agent_id: &str, blob: &CheckpointBlob) {
+    match serde_json::to_string(blob) {
+        Ok(s) => {
+            if let Err(e) = redis.agent_checkpoint_write(agent_id, &s).await {
+                debug!("redis agent_checkpoint_write {}: {}", agent_id, e);
+            }
+        }
+        Err(e) => debug!("checkpoint serialize {}: {}", agent_id, e),
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct RecoveryStats {
+    pub scanned: u64,
+    pub confirmed: u64,
+    pub abandoned: u64,
+    pub errors: u64,
+}
+
+/// Reconcile all pending intents after process restart. For each pending
+/// row, check whether the side-effect actually landed:
+///   * open_position: does a matching row in managed_agent_positions exist
+///     with opened_at >= intent.created_at? Confirmed: landed. Abandoned: no.
+///   * close_position: does the position_id still exist? Abandoned if yes
+///     (close never ran), confirmed if no (close landed).
+///   * post_order / cancel_order: not yet wired. Abandon with note.
+pub async fn recover_unresolved_intents(
+    pool: &PgPool,
+    redis: &RedisService,
+) -> Result<RecoveryStats, String> {
+    let mut stats = RecoveryStats::default();
+
+    let rows = sqlx::query(
+        "SELECT agent_id, seq, kind, payload::text AS payload_text, created_at \
+         FROM managed_agent_intents \
+         WHERE state = 'pending' \
+         ORDER BY agent_id, seq",
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(|e| e.to_string())?;
+
+    stats.scanned = rows.len() as u64;
+
+    for row in rows {
+        let agent_id: String = row.try_get("agent_id").unwrap_or_default();
+        let seq: i64 = row.try_get("seq").unwrap_or_default();
+        let kind: String = row.try_get("kind").unwrap_or_default();
+        let payload_text: String = row.try_get("payload_text").unwrap_or_else(|_| "{}".into());
+        let created_at: DateTime<Utc> = row.try_get("created_at").unwrap_or_else(|_| Utc::now());
+        let payload: serde_json::Value =
+            serde_json::from_str(&payload_text).unwrap_or(serde_json::Value::Null);
+
+        let handle = IntentHandle {
+            agent_id_key: fxhash(&agent_id),
+            seq,
+        };
+
+        let outcome = match kind.as_str() {
+            "open_position" => reconcile_open(pool, &agent_id, &payload, created_at).await,
+            "close_position" => reconcile_close(pool, &agent_id, &payload).await,
+            "post_order" | "cancel_order" => Ok(Reconciled::Abandon(
+                "order execution layer not wired".into(),
+            )),
+            other => Ok(Reconciled::Abandon(format!(
+                "unknown intent kind {}",
+                other
+            ))),
+        };
+
+        match outcome {
+            Ok(Reconciled::Confirm) => {
+                if let Err(e) = confirm_intent(pool, redis, &agent_id, handle).await {
+                    warn!("recover: confirm {}/{} failed: {}", agent_id, seq, e);
+                    stats.errors += 1;
+                } else {
+                    stats.confirmed += 1;
+                }
+            }
+            Ok(Reconciled::Abandon(note)) => {
+                if let Err(e) = abandon_intent(pool, redis, &agent_id, handle, &note).await {
+                    warn!("recover: abandon {}/{} failed: {}", agent_id, seq, e);
+                    stats.errors += 1;
+                } else {
+                    stats.abandoned += 1;
+                }
+            }
+            Err(e) => {
+                warn!("recover: reconcile {}/{} failed: {}", agent_id, seq, e);
+                stats.errors += 1;
+            }
+        }
+    }
+
+    Ok(stats)
+}
+
+enum Reconciled {
+    Confirm,
+    Abandon(String),
+}
+
+async fn reconcile_open(
+    pool: &PgPool,
+    agent_id: &str,
+    payload: &serde_json::Value,
+    created_at: DateTime<Utc>,
+) -> Result<Reconciled, String> {
+    let market_slug = payload.get("market_slug").and_then(|v| v.as_str());
+    let outcome = payload.get("outcome").and_then(|v| v.as_str());
+    let side = payload.get("side").and_then(|v| v.as_str());
+
+    let (Some(market_slug), Some(outcome), Some(side)) = (market_slug, outcome, side) else {
+        return Ok(Reconciled::Abandon(
+            "open_position payload malformed".into(),
+        ));
+    };
+
+    let exists: Option<i64> = sqlx::query_scalar(
+        "SELECT id FROM managed_agent_positions \
+         WHERE agent_id = $1 AND market_slug = $2 AND outcome = $3 AND side = $4 \
+           AND opened_at >= $5 - INTERVAL '5 seconds'",
+    )
+    .bind(agent_id)
+    .bind(market_slug)
+    .bind(outcome)
+    .bind(side)
+    .bind(created_at)
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| e.to_string())?;
+
+    if exists.is_some() {
+        Ok(Reconciled::Confirm)
+    } else {
+        Ok(Reconciled::Abandon(
+            "no matching position row — side-effect did not land".into(),
+        ))
+    }
+}
+
+async fn reconcile_close(
+    pool: &PgPool,
+    agent_id: &str,
+    payload: &serde_json::Value,
+) -> Result<Reconciled, String> {
+    let position_id = payload.get("position_id").and_then(|v| v.as_i64());
+    let Some(position_id) = position_id else {
+        return Ok(Reconciled::Abandon(
+            "close_position payload malformed".into(),
+        ));
+    };
+
+    let still_open: Option<i64> = sqlx::query_scalar(
+        "SELECT id FROM managed_agent_positions WHERE id = $1 AND agent_id = $2",
+    )
+    .bind(position_id)
+    .bind(agent_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| e.to_string())?;
+
+    if still_open.is_some() {
+        Ok(Reconciled::Abandon(
+            "position still open — close did not land, will be swept next tick".into(),
+        ))
+    } else {
+        Ok(Reconciled::Confirm)
+    }
+}
+
+fn fxhash(s: &str) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in s.as_bytes() {
+        h ^= *b as u64;
+        h = h.wrapping_mul(0x100_0000_01b3);
+    }
+    h
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_and_roundtrip() {
+        for s in [
+            "initializing",
+            "active",
+            "paused",
+            "liquidating",
+            "settled",
+            "failed",
+        ] {
+            let parsed = LifecycleState::parse(s).unwrap();
+            assert_eq!(parsed.as_str(), s);
+        }
+        assert!(LifecycleState::parse("nope").is_none());
+    }
+
+    #[test]
+    fn terminal_states_reject_transitions() {
+        for terminal in [LifecycleState::Settled, LifecycleState::Failed] {
+            for next in [
+                LifecycleState::Active,
+                LifecycleState::Paused,
+                LifecycleState::Liquidating,
+                LifecycleState::Initializing,
+            ] {
+                assert!(
+                    !terminal.can_transition_to(next),
+                    "{} → {} must be rejected",
+                    terminal,
+                    next
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn valid_happy_path() {
+        use LifecycleState::*;
+        assert!(Initializing.can_transition_to(Active));
+        assert!(Active.can_transition_to(Paused));
+        assert!(Paused.can_transition_to(Active));
+        assert!(Active.can_transition_to(Liquidating));
+        assert!(Liquidating.can_transition_to(Settled));
+        assert!(Initializing.can_transition_to(Failed));
+    }
+
+    #[test]
+    fn invalid_skip_transitions() {
+        use LifecycleState::*;
+        assert!(!Initializing.can_transition_to(Liquidating));
+        assert!(!Initializing.can_transition_to(Settled));
+        assert!(!Liquidating.can_transition_to(Active));
+        assert!(!Liquidating.can_transition_to(Paused));
+    }
+
+    #[test]
+    fn runnable_set_matches_runner_scan() {
+        assert!(LifecycleState::Active.is_runnable());
+        assert!(LifecycleState::Liquidating.is_runnable());
+        assert!(!LifecycleState::Paused.is_runnable());
+        assert!(!LifecycleState::Settled.is_runnable());
+        assert!(!LifecycleState::Failed.is_runnable());
+        assert!(!LifecycleState::Initializing.is_runnable());
+    }
+
+    #[test]
+    fn self_transition_is_noop_allowed() {
+        assert!(LifecycleState::Active.can_transition_to(LifecycleState::Active));
+    }
+}

--- a/app/src/services/managed_agent_runner.rs
+++ b/app/src/services/managed_agent_runner.rs
@@ -26,6 +26,7 @@ use crate::services::external::{
     fetch_market_by_id, fetch_markets, fetch_orderbook, ExternalMarketSource,
     ExternalMarketsRequest, TradableFilter,
 };
+use crate::services::managed_agent_lifecycle::{self as lifecycle, IntentKind, LifecycleState};
 use crate::AppState;
 
 /// Default tick interval for the managed agent runner (60 seconds).
@@ -62,6 +63,18 @@ pub fn spawn_managed_agent_runner(state: Arc<AppState>) {
     tokio::spawn(async move {
         // Stagger against the external agents scheduler.
         tokio::time::sleep(Duration::from_secs(12)).await;
+
+        // Reconcile any pending intents left over from a previous run before
+        // the first tick, so we don't double-execute side-effects whose
+        // confirmation was lost to a crash.
+        match lifecycle::recover_unresolved_intents(state.db.pool(), &state.redis).await {
+            Ok(r) if r.scanned > 0 => info!(
+                "lifecycle recovery: scanned={} confirmed={} abandoned={} errors={}",
+                r.scanned, r.confirmed, r.abandoned, r.errors
+            ),
+            Ok(_) => {}
+            Err(e) => warn!("lifecycle recovery failed: {}", e),
+        }
 
         let mut interval = tokio::time::interval(Duration::from_secs(interval_secs));
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -147,6 +160,14 @@ async fn run_tick(state: &AppState) -> Result<TickStats, String> {
     let now = Utc::now();
     let mut stats = TickStats::default();
 
+    // Reconcile user intent (`status`) into lifecycle transitions: if the
+    // user stopped an agent, move it out of `active` into `liquidating` (if
+    // positions are still open) or `settled` (if not). This must run before
+    // the scan so a just-stopped agent isn't evaluated one more time.
+    if let Err(e) = reconcile_status_transitions(state).await {
+        warn!("status reconcile: {}", e);
+    }
+
     // First: sweep positions that need closing (hold expired, or agent
     // stopped/paused). This must run even for paused agents so outstanding
     // positions don't stay open forever.
@@ -154,15 +175,25 @@ async fn run_tick(state: &AppState) -> Result<TickStats, String> {
         .await
         .map_err(|e| e.to_string())?;
 
-    // Then: load active agents whose next_execution_at is due.
+    // After sweep, liquidating agents with zero open positions transition
+    // to settled. Terminal.
+    if let Err(e) = finalize_liquidated_agents(state).await {
+        warn!("finalize settled: {}", e);
+    }
+
+    // Then: load active agents whose next_execution_at is due. We scan on
+    // lifecycle_state rather than user-facing status so paused agents
+    // (circuit-breaker or user-paused) are skipped while still letting the
+    // user keep status='active'.
     let rows = sqlx::query(
         "SELECT a.id, a.owner, a.template_id, a.seed_usdc, a.pnl_usdc, \
                 a.high_watermark_usdc, a.max_drawdown_pct, a.total_trades, \
                 a.params::text as params_text, a.consecutive_failures, \
+                a.lifecycle_state, \
                 t.strategy, t.category, t.min_seed_usdc \
          FROM managed_agents a \
          JOIN agent_templates t ON t.id = a.template_id \
-         WHERE a.status = 'active' AND a.next_execution_at <= $1 \
+         WHERE a.lifecycle_state = 'active' AND a.next_execution_at <= $1 \
          ORDER BY a.next_execution_at ASC, a.id ASC \
          LIMIT $2",
     )
@@ -179,13 +210,18 @@ async fn run_tick(state: &AppState) -> Result<TickStats, String> {
         let consecutive_failures: i32 = row.try_get("consecutive_failures").unwrap_or(0);
 
         if consecutive_failures >= MAX_CONSECUTIVE_FAILURES {
-            let _ = sqlx::query(
-                "UPDATE managed_agents SET status = 'stopped', last_error = $2, updated_at = NOW() WHERE id = $1",
+            let reason = format!("auto-paused after {} failures", consecutive_failures);
+            if let Err(e) = lifecycle::set_lifecycle_state(
+                state.db.pool(),
+                &state.redis,
+                id.as_str(),
+                LifecycleState::Paused,
+                Some(&reason),
             )
-            .bind(id.as_str())
-            .bind(format!("auto-stopped after {} failures", consecutive_failures))
-            .execute(state.db.pool())
-            .await;
+            .await
+            {
+                warn!("auto-pause {}: {}", id, e);
+            }
             continue;
         }
 
@@ -324,6 +360,28 @@ async fn sweep_due_positions(state: &AppState, now: DateTime<Utc>) -> anyhow::Re
             entry_fees + fill.fee_usdc,
         );
 
+        let close_payload = serde_json::json!({
+            "position_id": position_id,
+            "market_slug": market_slug,
+            "outcome": outcome,
+            "side": side,
+        });
+        let intent = match lifecycle::log_intent(
+            state.db.pool(),
+            &state.redis,
+            &agent_id,
+            lifecycle::IntentKind::ClosePosition,
+            &close_payload,
+        )
+        .await
+        {
+            Ok(h) => h,
+            Err(e) => {
+                warn!("sweep: log close intent {}: {}", position_id, e);
+                continue;
+            }
+        };
+
         let mut tx = state.db.pool().begin().await?;
 
         sqlx::query("DELETE FROM managed_agent_positions WHERE id = $1")
@@ -368,10 +426,97 @@ async fn sweep_due_positions(state: &AppState, now: DateTime<Utc>) -> anyhow::Re
         .await?;
 
         tx.commit().await?;
+        if let Err(e) =
+            lifecycle::confirm_intent(state.db.pool(), &state.redis, &agent_id, intent).await
+        {
+            warn!("sweep: confirm close intent {}: {}", position_id, e);
+        }
         closed += 1;
     }
 
     Ok(closed)
+}
+
+/// When a user flips `status` to 'stopped' or 'paused', move `lifecycle_state`
+/// out of `active`. Stopped → liquidating if positions still open, else
+/// settled. Paused user-intent → paused lifecycle.
+async fn reconcile_status_transitions(state: &AppState) -> Result<(), String> {
+    let rows = sqlx::query(
+        "SELECT a.id, a.status, a.lifecycle_state, \
+                (SELECT COUNT(*) FROM managed_agent_positions p \
+                 WHERE p.agent_id = a.id) AS open_count \
+         FROM managed_agents a \
+         WHERE (a.status = 'stopped' AND a.lifecycle_state IN ('active', 'paused')) \
+            OR (a.status = 'paused'  AND a.lifecycle_state = 'active') \
+            OR (a.status = 'active'  AND a.lifecycle_state = 'paused' \
+                AND a.consecutive_failures < $1) \
+         LIMIT 200",
+    )
+    .bind(MAX_CONSECUTIVE_FAILURES)
+    .fetch_all(state.db.pool())
+    .await
+    .map_err(|e| e.to_string())?;
+
+    for row in rows {
+        let id: String = row.try_get("id").unwrap_or_default();
+        let status: String = row.try_get("status").unwrap_or_default();
+        let open_count: i64 = row.try_get("open_count").unwrap_or(0);
+
+        let target = match (status.as_str(), open_count > 0) {
+            ("stopped", true) => LifecycleState::Liquidating,
+            ("stopped", false) => LifecycleState::Settled,
+            ("paused", _) => LifecycleState::Paused,
+            ("active", _) => LifecycleState::Active,
+            _ => continue,
+        };
+
+        let reason = match status.as_str() {
+            "stopped" => Some("user stop"),
+            "paused" => Some("user pause"),
+            "active" => Some("user resume"),
+            _ => None,
+        };
+
+        if let Err(e) =
+            lifecycle::set_lifecycle_state(state.db.pool(), &state.redis, &id, target, reason).await
+        {
+            warn!("reconcile {} → {}: {}", id, target, e);
+        }
+    }
+
+    Ok(())
+}
+
+/// Liquidating agents that have drained all positions move to settled.
+async fn finalize_liquidated_agents(state: &AppState) -> Result<(), String> {
+    let rows = sqlx::query(
+        "SELECT a.id FROM managed_agents a \
+         WHERE a.lifecycle_state = 'liquidating' \
+           AND NOT EXISTS ( \
+             SELECT 1 FROM managed_agent_positions p WHERE p.agent_id = a.id \
+           ) \
+         LIMIT 100",
+    )
+    .fetch_all(state.db.pool())
+    .await
+    .map_err(|e| e.to_string())?;
+
+    for row in rows {
+        let id: String = row.try_get("id").unwrap_or_default();
+        if let Err(e) = lifecycle::set_lifecycle_state(
+            state.db.pool(),
+            &state.redis,
+            &id,
+            LifecycleState::Settled,
+            Some("liquidation complete"),
+        )
+        .await
+        {
+            warn!("settle {}: {}", id, e);
+        }
+    }
+
+    Ok(())
 }
 
 /// Execute one active agent: count open positions, evaluate strategy for
@@ -705,6 +850,25 @@ async fn open_position(
         fill.filled_quantity,
     );
 
+    // Record the intent before the side-effect. If we crash after this
+    // point but before confirm_intent, recover_unresolved_intents will
+    // look up the position row and either confirm (side-effect landed) or
+    // abandon (did not).
+    let intent_payload = serde_json::json!({
+        "provider": market_id.provider.as_str(),
+        "market_slug": market_id.value,
+        "outcome": signal.outcome,
+        "side": signal.side,
+    });
+    let intent = lifecycle::log_intent(
+        state.db.pool(),
+        &state.redis,
+        &agent.id,
+        IntentKind::OpenPosition,
+        &intent_payload,
+    )
+    .await?;
+
     let mut tx = state.db.pool().begin().await.map_err(|e| e.to_string())?;
 
     // Insert position — ON CONFLICT DO NOTHING so a concurrent tick can't
@@ -739,6 +903,17 @@ async fn open_position(
 
     if inserted.rows_affected() == 0 {
         tx.rollback().await.ok();
+        // Unique-index conflict: another tick already opened this position.
+        // Nothing to confirm — abandon the intent so it doesn't get
+        // reconciled into a duplicate on restart.
+        let _ = lifecycle::abandon_intent(
+            state.db.pool(),
+            &state.redis,
+            &agent.id,
+            intent,
+            "duplicate — unique index conflict",
+        )
+        .await;
         return Ok(false);
     }
 
@@ -774,6 +949,9 @@ async fn open_position(
     .map_err(|e| e.to_string())?;
 
     tx.commit().await.map_err(|e| e.to_string())?;
+    lifecycle::confirm_intent(state.db.pool(), &state.redis, &agent.id, intent)
+        .await
+        .map_err(|e| format!("confirm open_position intent: {}", e))?;
     Ok(true)
 }
 

--- a/app/src/services/mod.rs
+++ b/app/src/services/mod.rs
@@ -17,6 +17,7 @@ pub mod limitless_partner;
 pub mod limitless_scanner;
 pub mod liquidity_mirror;
 pub mod logging;
+pub mod managed_agent_lifecycle;
 pub mod managed_agent_runner;
 pub mod market_creator;
 pub mod metrics;

--- a/app/src/services/redis.rs
+++ b/app/src/services/redis.rs
@@ -381,4 +381,58 @@ impl RedisService {
         let exists: bool = conn.exists(&key).await?;
         Ok(exists)
     }
+
+    // ── Managed agent lifecycle mirror ──────────────────────────────
+    //
+    // Postgres is source of truth for lifecycle_state + intents. These helpers
+    // mirror the hot-path state into Redis so runner startup can do a fast
+    // "who might need resume?" scan without walking every row in the agent
+    // table. Every helper degrades silently: Redis being down must not break
+    // the DB-backed lifecycle transitions.
+
+    /// Write the latest checkpoint blob for an agent. 7-day sliding TTL.
+    pub async fn agent_checkpoint_write(&self, agent_id: &str, payload: &str) -> Result<()> {
+        let key = format!("r44:agent:{}:checkpoint", agent_id);
+        let mut conn = self.conn()?;
+        let _: () = conn.set_ex(&key, payload, 7 * 24 * 3600).await?;
+        Ok(())
+    }
+
+    pub async fn agent_checkpoint_read(&self, agent_id: &str) -> Result<Option<String>> {
+        let key = format!("r44:agent:{}:checkpoint", agent_id);
+        let mut conn = self.conn()?;
+        let value: Option<String> = conn.get(&key).await?;
+        Ok(value)
+    }
+
+    /// Record a pending intent in the Redis mirror (hash keyed by seq).
+    pub async fn agent_intent_log(&self, agent_id: &str, seq: i64, payload: &str) -> Result<()> {
+        let key = format!("r44:agent:{}:intents:pending", agent_id);
+        let mut conn = self.conn()?;
+        let _: () = conn.hset(&key, seq, payload).await?;
+        let _: () = conn.expire(&key, 7 * 24 * 3600).await?;
+        Ok(())
+    }
+
+    /// Remove a resolved intent from the pending mirror.
+    pub async fn agent_intent_clear(&self, agent_id: &str, seq: i64) -> Result<()> {
+        let key = format!("r44:agent:{}:intents:pending", agent_id);
+        let mut conn = self.conn()?;
+        let _: () = conn.hdel(&key, seq).await?;
+        Ok(())
+    }
+
+    /// Mark an agent as runnable (lifecycle_state in active/liquidating) in
+    /// the per-runner candidate set.
+    pub async fn agent_active_mark(&self, agent_id: &str) -> Result<()> {
+        let mut conn = self.conn()?;
+        let _: () = conn.sadd("r44:agents:active", agent_id).await?;
+        Ok(())
+    }
+
+    pub async fn agent_active_unmark(&self, agent_id: &str) -> Result<()> {
+        let mut conn = self.conn()?;
+        let _: () = conn.srem("r44:agents:active", agent_id).await?;
+        Ok(())
+    }
 }

--- a/app/tests/managed_agent_lifecycle.rs
+++ b/app/tests/managed_agent_lifecycle.rs
@@ -1,0 +1,217 @@
+//! Integration tests for the managed-agent lifecycle + intent log.
+//!
+//! These tests require a migrated Postgres instance. They are gated behind
+//! the `TEST_DATABASE_URL` env var so `cargo test` in a plain dev setup
+//! skips them rather than erroring.
+//!
+//! Run with:
+//!   TEST_DATABASE_URL=postgres://user@localhost:5432/relay44_test \
+//!     cargo test --test managed_agent_lifecycle -- --test-threads=1
+
+use relay44_backend::services::managed_agent_lifecycle::{
+    self as lifecycle, IntentKind, LifecycleState,
+};
+use relay44_backend::services::RedisService;
+use sqlx::PgPool;
+
+async fn setup() -> Option<(PgPool, RedisService)> {
+    let url = std::env::var("TEST_DATABASE_URL").ok()?;
+    let pool = PgPool::connect(&url).await.ok()?;
+
+    sqlx::query("DELETE FROM managed_agent_intents")
+        .execute(&pool)
+        .await
+        .ok()?;
+    sqlx::query("DELETE FROM managed_agent_positions")
+        .execute(&pool)
+        .await
+        .ok()?;
+    sqlx::query("DELETE FROM managed_agents WHERE id LIKE 'test-lc-%'")
+        .execute(&pool)
+        .await
+        .ok()?;
+
+    let redis = RedisService::new("redis://127.0.0.1:6379")
+        .await
+        .expect("redis");
+
+    Some((pool, redis))
+}
+
+async fn make_agent(pool: &PgPool, id: &str) {
+    sqlx::query(
+        "INSERT INTO managed_agents \
+         (id, owner, template_id, name, params, seed_usdc, status, lifecycle_state) \
+         VALUES ($1, 'test-owner', (SELECT id FROM agent_templates LIMIT 1), \
+                 $1, '{}'::jsonb, 100.0, 'active', 'active') \
+         ON CONFLICT (id) DO UPDATE SET lifecycle_state = 'active'",
+    )
+    .bind(id)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn intent_log_confirm_roundtrip() {
+    let Some((pool, redis)) = setup().await else {
+        return;
+    };
+    make_agent(&pool, "test-lc-1").await;
+
+    let payload = serde_json::json!({
+        "provider": "polymarket",
+        "market_slug": "test-slug",
+        "outcome": "yes",
+        "side": "buy",
+    });
+
+    let handle = lifecycle::log_intent(
+        &pool,
+        &redis,
+        "test-lc-1",
+        IntentKind::OpenPosition,
+        &payload,
+    )
+    .await
+    .expect("log_intent");
+
+    assert_eq!(handle.seq, 1);
+
+    let pending: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM managed_agent_intents WHERE agent_id = 'test-lc-1' AND state = 'pending'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(pending, 1);
+
+    lifecycle::confirm_intent(&pool, &redis, "test-lc-1", handle)
+        .await
+        .expect("confirm");
+
+    let confirmed: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM managed_agent_intents WHERE agent_id = 'test-lc-1' AND state = 'confirmed'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(confirmed, 1);
+}
+
+#[tokio::test]
+async fn recover_abandons_pending_open_with_no_position() {
+    let Some((pool, redis)) = setup().await else {
+        return;
+    };
+    make_agent(&pool, "test-lc-2").await;
+
+    let payload = serde_json::json!({
+        "provider": "polymarket",
+        "market_slug": "ghost-market",
+        "outcome": "yes",
+        "side": "buy",
+    });
+    let _ = lifecycle::log_intent(
+        &pool,
+        &redis,
+        "test-lc-2",
+        IntentKind::OpenPosition,
+        &payload,
+    )
+    .await
+    .unwrap();
+
+    let stats = lifecycle::recover_unresolved_intents(&pool, &redis)
+        .await
+        .unwrap();
+    assert_eq!(stats.abandoned, 1);
+    assert_eq!(stats.confirmed, 0);
+}
+
+#[tokio::test]
+async fn recover_confirms_pending_open_with_matching_position() {
+    let Some((pool, redis)) = setup().await else {
+        return;
+    };
+    make_agent(&pool, "test-lc-3").await;
+
+    let payload = serde_json::json!({
+        "provider": "polymarket",
+        "market_slug": "real-market",
+        "outcome": "yes",
+        "side": "buy",
+    });
+    let _ = lifecycle::log_intent(
+        &pool,
+        &redis,
+        "test-lc-3",
+        IntentKind::OpenPosition,
+        &payload,
+    )
+    .await
+    .unwrap();
+
+    sqlx::query(
+        "INSERT INTO managed_agent_positions \
+         (agent_id, market_slug, provider, outcome, side, entry_price, quantity, \
+          notional_usdc, mark_price, hold_until) \
+         VALUES ('test-lc-3', 'real-market', 'polymarket', 'yes', 'buy', \
+                 0.5, 10.0, 5.0, 0.5, NOW() + INTERVAL '10 minutes')",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let stats = lifecycle::recover_unresolved_intents(&pool, &redis)
+        .await
+        .unwrap();
+    assert_eq!(stats.confirmed, 1);
+    assert_eq!(stats.abandoned, 0);
+}
+
+#[tokio::test]
+async fn invalid_transition_is_rejected() {
+    let Some((pool, redis)) = setup().await else {
+        return;
+    };
+    make_agent(&pool, "test-lc-4").await;
+
+    lifecycle::set_lifecycle_state(&pool, &redis, "test-lc-4", LifecycleState::Settled, None)
+        .await
+        .expect("settle ok");
+
+    let res = lifecycle::set_lifecycle_state(
+        &pool,
+        &redis,
+        "test-lc-4",
+        LifecycleState::Active,
+        Some("should fail"),
+    )
+    .await;
+
+    assert!(res.is_err(), "settled → active must be rejected");
+}
+
+#[tokio::test]
+async fn seq_is_monotonic_across_intents() {
+    let Some((pool, redis)) = setup().await else {
+        return;
+    };
+    make_agent(&pool, "test-lc-5").await;
+
+    let p = serde_json::json!({"market_slug": "x", "outcome": "yes", "side": "buy"});
+    let h1 = lifecycle::log_intent(&pool, &redis, "test-lc-5", IntentKind::OpenPosition, &p)
+        .await
+        .unwrap();
+    let h2 = lifecycle::log_intent(&pool, &redis, "test-lc-5", IntentKind::OpenPosition, &p)
+        .await
+        .unwrap();
+    let h3 = lifecycle::log_intent(&pool, &redis, "test-lc-5", IntentKind::OpenPosition, &p)
+        .await
+        .unwrap();
+
+    assert_eq!(h1.seq, 1);
+    assert_eq!(h2.seq, 2);
+    assert_eq!(h3.seq, 3);
+}

--- a/migrations/055_agent_lifecycle.sql
+++ b/migrations/055_agent_lifecycle.sql
@@ -1,0 +1,60 @@
+-- Managed agent lifecycle states + durable intent log.
+--
+-- Turns a managed agent from a cron row into a recoverable protocol object:
+--   * `lifecycle_state` tracks runtime execution (initializing → active ⇄ paused,
+--     → liquidating → settled, or → failed). Distinct from user-facing `status`
+--     so the runner can pause on failures without overriding user intent.
+--   * `managed_agent_intents` is an append-only log written before every
+--     external side-effect (open_position, close_position, post_order,
+--     cancel_order). On process restart the runner reconciles any `pending`
+--     intents against observed state and marks them confirmed or abandoned
+--     instead of silently re-executing.
+
+ALTER TABLE managed_agents
+    ADD COLUMN IF NOT EXISTS lifecycle_state VARCHAR(32) NOT NULL DEFAULT 'initializing';
+
+ALTER TABLE managed_agents
+    ADD COLUMN IF NOT EXISTS lifecycle_updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
+ALTER TABLE managed_agents
+    ADD COLUMN IF NOT EXISTS last_checkpoint_at TIMESTAMPTZ;
+
+ALTER TABLE managed_agents
+    ADD COLUMN IF NOT EXISTS last_checkpoint_seq BIGINT NOT NULL DEFAULT 0;
+
+ALTER TABLE managed_agents
+    ADD COLUMN IF NOT EXISTS failure_reason TEXT;
+
+UPDATE managed_agents
+SET lifecycle_state = CASE
+    WHEN status = 'active'  THEN 'active'
+    WHEN status = 'stopped' THEN 'settled'
+    WHEN status = 'paused'  THEN 'paused'
+    ELSE 'active'
+END,
+    lifecycle_updated_at = NOW()
+WHERE lifecycle_state = 'initializing';
+
+CREATE INDEX IF NOT EXISTS idx_managed_agents_lifecycle
+    ON managed_agents(lifecycle_state, next_execution_at)
+    WHERE lifecycle_state IN ('active', 'liquidating');
+
+CREATE TABLE IF NOT EXISTS managed_agent_intents (
+    id              BIGSERIAL PRIMARY KEY,
+    agent_id        VARCHAR(64) NOT NULL REFERENCES managed_agents(id) ON DELETE CASCADE,
+    seq             BIGINT NOT NULL,
+    kind            VARCHAR(32) NOT NULL,
+    payload         JSONB NOT NULL DEFAULT '{}'::jsonb,
+    state           VARCHAR(16) NOT NULL DEFAULT 'pending',
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    resolved_at     TIMESTAMPTZ,
+    resolution_note TEXT,
+    UNIQUE (agent_id, seq)
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_intents_pending
+    ON managed_agent_intents(agent_id)
+    WHERE state = 'pending';
+
+CREATE INDEX IF NOT EXISTS idx_agent_intents_created
+    ON managed_agent_intents(created_at DESC);


### PR DESCRIPTION
## Summary

- turns a managed agent from a cron row into a recoverable protocol object: explicit `lifecycle_state` (initializing/active/paused/liquidating/settled/failed) distinct from user-facing `status`
- adds a pre-commit intent log so crashes between "decided to open position" and "position row inserted" are reconciled on restart rather than silently re-executed
- piece #1 of the PTE integration — the lifecycle + intent primitives the later pieces (normalized L2 deltas, batch `postOrders` through the forwarder) will hang off

## Why this shape

Before: `status` is a single string ('active'/'stopped'), all runtime state lives in memory, process restart has no resume path. The 20-consecutive-failures auto-stop clobbers the user's `status`, and a crash mid-`execute_agent` can leave us double-posting once the process comes back.

After: user intent (`status`) and runtime state (`lifecycle_state`) are orthogonal columns. Every external side-effect is bracketed with `log_intent` / `confirm_intent`; `recover_unresolved_intents` runs once at runner startup and reconciles pending rows against observed state (position row exists? confirm. not there? abandon with note). Redis mirrors the hot path for observability but Postgres is authoritative — Redis outages log-and-continue.

## Commits

1. migration 055 — schema + backfill
2. redis mirror helpers
3. lifecycle service (state machine, intent log, recovery) + 6 unit tests
4. runner wiring (scan by lifecycle_state, auto-pause instead of auto-stop, intent-bracketed open/close, status→lifecycle reconcile, liquidating→settled finalizer)
5. DB-gated integration tests

## Test plan

- [x] cargo check clean
- [x] cargo test --lib managed_agent_lifecycle — 6 unit tests pass
- [ ] apply migration 055 against staging DB, confirm status/lifecycle_state mapping
- [ ] TEST_DATABASE_URL=… cargo test --test managed_agent_lifecycle — 5 integration tests
- [ ] deploy to staging, verify no stuck initializing/liquidating rows
- [ ] force 20 consecutive errors, confirm paused not stopped
- [ ] user-stop with open positions walks liquidating → settled

## Out of scope

- normalized L2 delta events (PTE piece #2)
- batch postOrders through forwarder (PTE piece #3)
- UI state-diagram — schema ready, UI follows separately