### PR TITLE
market-data bus: unified L2 event layer

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -41,8 +41,8 @@ use actix_web::web;
 use api::JwtService;
 use config::AppConfig;
 use services::{
-    DatabaseService, EventBus, EvmIndexerService, EvmRpcService, MetricsService, OrderBookService,
-    RedisService, WebSocketHub,
+    market_data::MarketDataBus, DatabaseService, EventBus, EvmIndexerService, EvmRpcService,
+    MetricsService, OrderBookService, RedisService, WebSocketHub,
 };
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
@@ -58,6 +58,7 @@ pub struct AppState {
     pub metrics: MetricsService,
     pub ws_hub: WebSocketHub,
     pub event_bus: EventBus,
+    pub market_data: Arc<MarketDataBus>,
     pub kyc: services::kyc::KycService,
     pub limitless_partner: Option<services::limitless_partner::LimitlessPartnerConfig>,
     pub is_shutting_down: Arc<AtomicBool>,

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -87,6 +87,7 @@ async fn main() -> std::io::Result<()> {
     let metrics = MetricsService::new();
     let ws_hub = WebSocketHub::new();
     let event_bus = EventBus::new();
+    let market_data = Arc::new(relay44_backend::services::market_data::MarketDataBus::new());
 
     let kyc = relay44_backend::services::kyc::KycService::new(
         relay44_backend::services::kyc::KycConfig::from_env(),
@@ -105,10 +106,13 @@ async fn main() -> std::io::Result<()> {
         metrics,
         ws_hub,
         event_bus,
+        market_data,
         kyc,
         limitless_partner,
         is_shutting_down: Arc::new(AtomicBool::new(false)),
     });
+
+    relay44_backend::services::market_data::cache_writer::spawn(app_state.clone());
 
     let migration_db = app_state.db.clone();
     let background_state = app_state.clone();

--- a/app/src/services/aerodrome_scanner.rs
+++ b/app/src/services/aerodrome_scanner.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::services::external::providers::aerodrome;
+use crate::services::market_data::{market_key, L2Event, L2Level, L2Payload, Venue};
 use crate::AppState;
 
 // ── Scanner entry point ──
@@ -124,6 +125,35 @@ async fn run_scan(state: &AppState) -> Result<(i32, i32, i32), String> {
         // Synthesize orderbook to compute spread.
         let orderbook = aerodrome::synthesize_orderbook(&pool_state, pool_address, price);
         let spread_bps = compute_spread_bps(&orderbook);
+
+        let seq = state.market_data.next_seq(Venue::Aerodrome);
+        state.market_data.emit(L2Event {
+            venue: Venue::Aerodrome,
+            market_key: market_key(Venue::Aerodrome, &[pool_address]),
+            seq,
+            observed_at: chrono::Utc::now(),
+            payload: L2Payload::Snapshot {
+                bids: orderbook
+                    .bids
+                    .iter()
+                    .take(10)
+                    .map(|l| L2Level {
+                        price: l.price,
+                        size: l.quantity,
+                    })
+                    .collect(),
+                asks: orderbook
+                    .asks
+                    .iter()
+                    .take(10)
+                    .map(|l| L2Level {
+                        price: l.price,
+                        size: l.quantity,
+                    })
+                    .collect(),
+                last_trade: None,
+            },
+        });
 
         let (opp_type, opp_score) = score_opportunity(&pool_state, spread_bps);
         if opp_score > 0.0 {

--- a/app/src/services/limitless_scanner.rs
+++ b/app/src/services/limitless_scanner.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 
 use crate::services::external::providers::limitless;
 use crate::services::external::types::ExternalMarketSnapshot;
+use crate::services::market_data::{market_key, L2Event, L2Level, L2Payload, Venue};
 use crate::AppState;
 
 // ── Scanner entry point ──
@@ -141,6 +142,24 @@ async fn run_scan(state: &AppState) -> Result<(i32, i32, i32), String> {
             continue;
         }
         indexed += 1;
+
+        for (outcome, price) in [("yes", market.yes_price), ("no", market.no_price)] {
+            if price <= 0.0 {
+                continue;
+            }
+            let seq = state.market_data.next_seq(Venue::Limitless);
+            state.market_data.emit(L2Event {
+                venue: Venue::Limitless,
+                market_key: market_key(Venue::Limitless, &[slug, outcome]),
+                seq,
+                observed_at: chrono::Utc::now(),
+                payload: L2Payload::Snapshot {
+                    bids: vec![L2Level { price, size: 0.0 }],
+                    asks: vec![],
+                    last_trade: None,
+                },
+            });
+        }
     }
 
     // Cross-venue matching against Polymarket.

--- a/app/src/services/market_data/bus.rs
+++ b/app/src/services/market_data/bus.rs
@@ -1,0 +1,72 @@
+//! In-process broadcast bus for L2 market-data events.
+//!
+//! Producers emit here; the `cache_writer` task is the single Redis-side
+//! subscriber, so producers stay ignorant of Redis. Late consumers that see
+//! `RecvError::Lagged` should reconcile from `L2Cache::read_top`.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use log::warn;
+use tokio::sync::broadcast;
+
+use super::{L2Event, Venue};
+
+const MARKET_DATA_BUS_CAPACITY: usize = 4096;
+
+pub struct MarketDataBus {
+    tx: broadcast::Sender<Arc<L2Event>>,
+    seq_polymarket: AtomicU64,
+    seq_limitless: AtomicU64,
+    seq_aerodrome: AtomicU64,
+    seq_internal: AtomicU64,
+}
+
+impl MarketDataBus {
+    pub fn new() -> Self {
+        let (tx, _) = broadcast::channel(MARKET_DATA_BUS_CAPACITY);
+        Self {
+            tx,
+            seq_polymarket: AtomicU64::new(0),
+            seq_limitless: AtomicU64::new(0),
+            seq_aerodrome: AtomicU64::new(0),
+            seq_internal: AtomicU64::new(0),
+        }
+    }
+
+    /// Monotonic per-venue sequence number. Consumers use it to detect gaps
+    /// on a single channel; it does not need to be per-market because the
+    /// reconciliation substrate (snapshot cache) is keyed by market.
+    pub fn next_seq(&self, venue: Venue) -> u64 {
+        let counter = match venue {
+            Venue::Polymarket => &self.seq_polymarket,
+            Venue::Limitless => &self.seq_limitless,
+            Venue::Aerodrome => &self.seq_aerodrome,
+            Venue::Internal => &self.seq_internal,
+        };
+        counter.fetch_add(1, Ordering::Relaxed) + 1
+    }
+
+    pub fn emit(&self, event: L2Event) {
+        if self.tx.receiver_count() == 0 {
+            return;
+        }
+        if let Err(e) = self.tx.send(Arc::new(event)) {
+            warn!("market_data bus send failed: {}", e);
+        }
+    }
+
+    pub fn subscribe(&self) -> broadcast::Receiver<Arc<L2Event>> {
+        self.tx.subscribe()
+    }
+
+    pub fn receiver_count(&self) -> usize {
+        self.tx.receiver_count()
+    }
+}
+
+impl Default for MarketDataBus {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/app/src/services/market_data/cache.rs
+++ b/app/src/services/market_data/cache.rs
@@ -1,0 +1,46 @@
+//! Redis-backed top-of-book cache for L2 events.
+//!
+//! Consumers that lag on the in-process bus reconcile by reading from here.
+//! Keys: `r44:l2:top:{venue}:{market_key}` with a 30s sliding TTL — a silent
+//! venue naturally expires so callers can fall back to direct fetches.
+
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::{L2Level, Venue};
+use crate::services::RedisService;
+
+pub const TOP_OF_BOOK_TTL_SECS: u64 = 30;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TopOfBook {
+    pub best_bid: Option<L2Level>,
+    pub best_ask: Option<L2Level>,
+    pub last_trade: Option<f64>,
+    pub seq: u64,
+    pub observed_at: DateTime<Utc>,
+}
+
+fn top_key(venue: Venue, market_key: &str) -> String {
+    format!("r44:l2:top:{}:{}", venue.as_str(), market_key)
+}
+
+pub async fn write_top(
+    redis: &RedisService,
+    venue: Venue,
+    market_key: &str,
+    top: &TopOfBook,
+) -> Result<()> {
+    redis
+        .set(&top_key(venue, market_key), top, Some(TOP_OF_BOOK_TTL_SECS))
+        .await
+}
+
+pub async fn read_top(
+    redis: &RedisService,
+    venue: Venue,
+    market_key: &str,
+) -> Result<Option<TopOfBook>> {
+    redis.get(&top_key(venue, market_key)).await
+}

--- a/app/src/services/market_data/cache_writer.rs
+++ b/app/src/services/market_data/cache_writer.rs
@@ -1,0 +1,71 @@
+//! Single subscriber task that (1) folds L2 events into a top-of-book
+//! snapshot in Redis and (2) re-publishes events on Redis pub/sub for
+//! cross-process consumers (Next.js frontend, future workers).
+//!
+//! Producers stay Redis-free; this task owns the Redis side of the bus.
+
+use std::sync::Arc;
+
+use log::{debug, warn};
+use tokio::sync::broadcast::error::RecvError;
+
+use super::{cache, L2Event, L2Payload, TopOfBook};
+use crate::AppState;
+
+pub fn spawn(state: Arc<AppState>) -> tokio::task::JoinHandle<()> {
+    let mut rx = state.market_data.subscribe();
+    tokio::spawn(async move {
+        loop {
+            match rx.recv().await {
+                Ok(ev) => handle_event(&state, ev).await,
+                Err(RecvError::Lagged(n)) => {
+                    warn!("market_data cache_writer lagged by {} events", n);
+                }
+                Err(RecvError::Closed) => {
+                    debug!("market_data bus closed; cache_writer exiting");
+                    return;
+                }
+            }
+        }
+    })
+}
+
+async fn handle_event(state: &AppState, ev: Arc<L2Event>) {
+    if let Some(top) = fold_top(&ev) {
+        if let Err(e) =
+            cache::write_top(&state.redis, ev.venue, &ev.market_key, &top).await
+        {
+            warn!("l2 cache write failed: {}", e);
+        }
+    }
+
+    match serde_json::to_string(&*ev) {
+        Ok(payload) => {
+            let channel = format!("r44:l2:{}:{}", ev.venue.as_str(), ev.market_key);
+            if let Err(e) = state.redis.publish(&channel, &payload).await {
+                warn!("l2 pubsub publish failed ({}): {}", channel, e);
+            }
+            if let Err(e) = state.redis.publish("r44:l2:firehose", &payload).await {
+                warn!("l2 pubsub firehose publish failed: {}", e);
+            }
+        }
+        Err(e) => warn!("l2 event serialize failed: {}", e),
+    }
+}
+
+fn fold_top(ev: &L2Event) -> Option<TopOfBook> {
+    match &ev.payload {
+        L2Payload::Snapshot {
+            bids,
+            asks,
+            last_trade,
+        } => Some(TopOfBook {
+            best_bid: bids.first().cloned(),
+            best_ask: asks.first().cloned(),
+            last_trade: *last_trade,
+            seq: ev.seq,
+            observed_at: ev.observed_at,
+        }),
+        L2Payload::Delta { .. } | L2Payload::Trade { .. } => None,
+    }
+}

--- a/app/src/services/market_data/mod.rs
+++ b/app/src/services/market_data/mod.rs
@@ -1,0 +1,94 @@
+//! Unified, versioned market-data event layer.
+//!
+//! Every producer (polymarket_ws, *_scanner, aerodrome_scanner, ...) emits
+//! `L2Event`s through `MarketDataBus`. The `cache_writer` task subscribes,
+//! maintains a top-of-book snapshot in Redis for lagged / cross-process
+//! consumers, and fans out raw events on `r44:l2:{venue}:{market}` so the
+//! Next.js frontend and future workers can stay in sync without polling.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+pub mod bus;
+pub mod cache;
+pub mod cache_writer;
+
+pub use bus::MarketDataBus;
+pub use cache::TopOfBook;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Venue {
+    Polymarket,
+    Limitless,
+    Aerodrome,
+    Internal,
+}
+
+impl Venue {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Venue::Polymarket => "polymarket",
+            Venue::Limitless => "limitless",
+            Venue::Aerodrome => "aerodrome",
+            Venue::Internal => "internal",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Side {
+    Buy,
+    Sell,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct L2Level {
+    pub price: f64,
+    pub size: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum L2Payload {
+    /// Absolute book state. Self-sufficient; safe to receive without prior context.
+    Snapshot {
+        bids: Vec<L2Level>,
+        asks: Vec<L2Level>,
+        last_trade: Option<f64>,
+    },
+    /// Per-level changes. Consumers that miss one must reconcile from the cache.
+    Delta {
+        bid_updates: Vec<L2Level>,
+        ask_updates: Vec<L2Level>,
+        removed_bids: Vec<f64>,
+        removed_asks: Vec<f64>,
+    },
+    /// Trade print. Does not mutate the book.
+    Trade {
+        price: f64,
+        size: f64,
+        side: Side,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct L2Event {
+    pub venue: Venue,
+    pub market_key: String,
+    pub seq: u64,
+    pub observed_at: DateTime<Utc>,
+    pub payload: L2Payload,
+}
+
+/// Canonical market-key format. Keep producers aligned with consumers.
+pub fn market_key(venue: Venue, parts: &[&str]) -> String {
+    let mut s = String::with_capacity(32);
+    s.push_str(venue.as_str());
+    for p in parts {
+        s.push(':');
+        s.push_str(p);
+    }
+    s
+}

--- a/app/src/services/mod.rs
+++ b/app/src/services/mod.rs
@@ -20,6 +20,7 @@ pub mod logging;
 pub mod managed_agent_lifecycle;
 pub mod managed_agent_runner;
 pub mod market_creator;
+pub mod market_data;
 pub mod metrics;
 pub mod orchestrator;
 pub mod orderbook;

--- a/app/src/services/polymarket_scanner.rs
+++ b/app/src/services/polymarket_scanner.rs
@@ -9,7 +9,26 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::services::market_data::{L2Event, L2Level, L2Payload, Venue};
 use crate::AppState;
+
+fn emit_l2(state: &AppState, market_key: String, price: f64) {
+    if price <= 0.0 {
+        return;
+    }
+    let seq = state.market_data.next_seq(Venue::Polymarket);
+    state.market_data.emit(L2Event {
+        venue: Venue::Polymarket,
+        market_key,
+        seq,
+        observed_at: chrono::Utc::now(),
+        payload: L2Payload::Snapshot {
+            bids: vec![L2Level { price, size: 0.0 }],
+            asks: vec![],
+            last_trade: None,
+        },
+    });
+}
 
 // ── Gamma API types ──
 
@@ -491,6 +510,8 @@ pub async fn run_scan(state: &AppState) -> Result<Vec<ScannedOpportunity>, Strin
                 if let Err(e) = upsert_scanned_market(state, &opp).await {
                     warn!("Scanner: failed to persist {}: {}", opp.condition_id, e);
                 }
+                emit_l2(state, opp.yes_token_id.clone(), opp.yes_price);
+                emit_l2(state, opp.no_token_id.clone(), opp.no_price);
                 all_opportunities.push(opp);
             }
         }

--- a/app/src/services/polymarket_ws.rs
+++ b/app/src/services/polymarket_ws.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
 
+use crate::services::market_data::{L2Event, L2Level, L2Payload, Venue};
 use crate::AppState;
 
 const WS_URL: &str = "wss://ws-subscriptions-clob.polymarket.com/ws/market";
@@ -192,7 +193,7 @@ pub fn spawn_orderbook_feed(
                 break;
             }
 
-            match run_ws_connection(&orderbooks, &token_ids).await {
+            match run_ws_connection(&state, &orderbooks, &token_ids).await {
                 Ok(()) => {
                     info!("PM WS connection closed cleanly");
                 }
@@ -215,6 +216,7 @@ pub fn spawn_orderbook_feed(
 }
 
 async fn run_ws_connection(
+    state: &AppState,
     orderbooks: &SharedOrderbooks,
     token_ids: &[String],
 ) -> Result<(), String> {
@@ -270,10 +272,10 @@ async fn run_ws_connection(
                 // Try to parse as array (Polymarket sends arrays of events)
                 if let Ok(messages) = serde_json::from_str::<Vec<WsMessage>>(&text) {
                     for ws_msg in messages {
-                        process_ws_message(orderbooks, ws_msg).await;
+                        process_ws_message(state, orderbooks, ws_msg).await;
                     }
                 } else if let Ok(ws_msg) = serde_json::from_str::<WsMessage>(&text) {
-                    process_ws_message(orderbooks, ws_msg).await;
+                    process_ws_message(state, orderbooks, ws_msg).await;
                 }
                 // Silently ignore unparseable messages
             }
@@ -289,7 +291,7 @@ async fn run_ws_connection(
     Ok(())
 }
 
-async fn process_ws_message(orderbooks: &SharedOrderbooks, msg: WsMessage) {
+async fn process_ws_message(state: &AppState, orderbooks: &SharedOrderbooks, msg: WsMessage) {
     match msg {
         WsMessage::Book {
             asset_id,
@@ -312,6 +314,9 @@ async fn process_ws_message(orderbooks: &SharedOrderbooks, msg: WsMessage) {
                     .unwrap_or(std::cmp::Ordering::Equal)
             });
 
+            let (snapshot_bids, snapshot_asks) = (parsed_bids.clone(), parsed_asks.clone());
+            let token_key = asset_id.clone();
+
             let mut books = orderbooks.write().await;
             let entry = books
                 .entry(asset_id.clone())
@@ -322,33 +327,64 @@ async fn process_ws_message(orderbooks: &SharedOrderbooks, msg: WsMessage) {
             entry.bids = parsed_bids;
             entry.asks = parsed_asks;
             entry.updated_at = std::time::Instant::now();
+            let last_trade = entry.last_trade_price;
+            drop(books);
+
+            let seq = state.market_data.next_seq(Venue::Polymarket);
+            state.market_data.emit(L2Event {
+                venue: Venue::Polymarket,
+                market_key: token_key,
+                seq,
+                observed_at: chrono::Utc::now(),
+                payload: L2Payload::Snapshot {
+                    bids: snapshot_bids
+                        .into_iter()
+                        .take(10)
+                        .map(|l| L2Level { price: l.price, size: l.size })
+                        .collect(),
+                    asks: snapshot_asks
+                        .into_iter()
+                        .take(10)
+                        .map(|l| L2Level { price: l.price, size: l.size })
+                        .collect(),
+                    last_trade,
+                },
+            });
         }
 
         WsMessage::PriceChange {
             asset_id, changes, ..
         } => {
+            let mut bid_updates = Vec::new();
+            let mut ask_updates = Vec::new();
+            let mut removed_bids = Vec::new();
+            let mut removed_asks = Vec::new();
+
             let mut books = orderbooks.write().await;
             if let Some(entry) = books.get_mut(&asset_id) {
-                for change in changes {
+                for change in &changes {
                     if let (Ok(price), Ok(size)) =
                         (change.price.parse::<f64>(), change.size.parse::<f64>())
                     {
-                        let levels = if change.side == "BUY" || change.side == "buy" {
-                            &mut entry.bids
-                        } else {
-                            &mut entry.asks
-                        };
+                        let is_bid = change.side == "BUY" || change.side == "buy";
+                        let levels = if is_bid { &mut entry.bids } else { &mut entry.asks };
 
-                        // Remove existing level at this price
                         levels.retain(|l| (l.price - price).abs() > f64::EPSILON);
 
-                        // Add back if size > 0
                         if size > 0.0 {
                             levels.push(PriceLevel { price, size });
+                            if is_bid {
+                                bid_updates.push(L2Level { price, size });
+                            } else {
+                                ask_updates.push(L2Level { price, size });
+                            }
+                        } else if is_bid {
+                            removed_bids.push(price);
+                        } else {
+                            removed_asks.push(price);
                         }
 
-                        // Re-sort
-                        if change.side == "BUY" || change.side == "buy" {
+                        if is_bid {
                             levels.sort_by(|a, b| {
                                 b.price
                                     .partial_cmp(&a.price)
@@ -364,6 +400,27 @@ async fn process_ws_message(orderbooks: &SharedOrderbooks, msg: WsMessage) {
                     }
                 }
                 entry.updated_at = std::time::Instant::now();
+                drop(books);
+
+                if !bid_updates.is_empty()
+                    || !ask_updates.is_empty()
+                    || !removed_bids.is_empty()
+                    || !removed_asks.is_empty()
+                {
+                    let seq = state.market_data.next_seq(Venue::Polymarket);
+                    state.market_data.emit(L2Event {
+                        venue: Venue::Polymarket,
+                        market_key: asset_id,
+                        seq,
+                        observed_at: chrono::Utc::now(),
+                        payload: L2Payload::Delta {
+                            bid_updates,
+                            ask_updates,
+                            removed_bids,
+                            removed_asks,
+                        },
+                    });
+                }
             }
         }
 

--- a/app/tests/common/mod.rs
+++ b/app/tests/common/mod.rs
@@ -38,6 +38,7 @@ pub async fn build_test_state() -> Arc<AppState> {
     let metrics = MetricsService::new();
     let ws_hub = WebSocketHub::new();
     let event_bus = EventBus::new();
+    let market_data = Arc::new(relay44_backend::services::market_data::MarketDataBus::new());
     let kyc = relay44_backend::services::kyc::KycService::new(
         relay44_backend::services::kyc::KycConfig::from_env(),
     );
@@ -53,6 +54,7 @@ pub async fn build_test_state() -> Arc<AppState> {
         metrics,
         ws_hub,
         event_bus,
+        market_data,
         kyc,
         limitless_partner: None,
         is_shutting_down: Arc::new(AtomicBool::new(false)),

--- a/app/tests/market_data_bus.rs
+++ b/app/tests/market_data_bus.rs
@@ -1,0 +1,75 @@
+//! Smoke tests for the market-data bus envelope + seq counters.
+//!
+//! No Redis required — the bus itself is pure in-process broadcast. Cache
+//! and pub/sub fanout are exercised via the `cache_writer` task, which is
+//! tested separately when `TEST_REDIS_URL` is set.
+
+use std::sync::Arc;
+
+use relay44_backend::services::market_data::{
+    L2Event, L2Level, L2Payload, MarketDataBus, Venue,
+};
+
+fn snapshot(market: &str, seq: u64, price: f64) -> L2Event {
+    L2Event {
+        venue: Venue::Polymarket,
+        market_key: market.to_string(),
+        seq,
+        observed_at: chrono::Utc::now(),
+        payload: L2Payload::Snapshot {
+            bids: vec![L2Level { price, size: 1.0 }],
+            asks: vec![],
+            last_trade: None,
+        },
+    }
+}
+
+#[tokio::test]
+async fn bus_delivers_to_subscriber() {
+    let bus = Arc::new(MarketDataBus::new());
+    let mut rx = bus.subscribe();
+
+    bus.emit(snapshot("token-1", 1, 0.42));
+
+    let ev = rx.recv().await.expect("receive");
+    assert_eq!(ev.market_key, "token-1");
+    assert_eq!(ev.seq, 1);
+}
+
+#[tokio::test]
+async fn emit_without_subscribers_is_noop() {
+    let bus = MarketDataBus::new();
+    bus.emit(snapshot("token-x", 1, 0.5));
+    assert_eq!(bus.receiver_count(), 0);
+}
+
+#[tokio::test]
+async fn seq_is_monotonic_per_venue() {
+    let bus = MarketDataBus::new();
+    let a = bus.next_seq(Venue::Polymarket);
+    let b = bus.next_seq(Venue::Polymarket);
+    let c = bus.next_seq(Venue::Polymarket);
+    assert_eq!((a, b, c), (1, 2, 3));
+
+    let lim_a = bus.next_seq(Venue::Limitless);
+    let lim_b = bus.next_seq(Venue::Limitless);
+    assert_eq!((lim_a, lim_b), (1, 2));
+    assert_eq!(bus.next_seq(Venue::Polymarket), 4);
+}
+
+#[tokio::test]
+async fn multiple_subscribers_each_receive_events() {
+    let bus = Arc::new(MarketDataBus::new());
+    let mut rx1 = bus.subscribe();
+    let mut rx2 = bus.subscribe();
+
+    bus.emit(snapshot("m", 1, 0.1));
+    bus.emit(snapshot("m", 2, 0.2));
+
+    for rx in [&mut rx1, &mut rx2] {
+        let e1 = rx.recv().await.unwrap();
+        let e2 = rx.recv().await.unwrap();
+        assert_eq!(e1.seq, 1);
+        assert_eq!(e2.seq, 2);
+    }
+}


### PR DESCRIPTION
## Summary

PTE piece #2 foundation. Unified, versioned market-data event layer so producers stop owning their own caches and consumers can stop re-implementing quote fetching.

- New module `services::market_data` with `L2Event` envelope (`Snapshot` / `Delta` / `Trade`), `Venue` enum, and canonical `market_key()` helper
- `MarketDataBus`: in-process tokio broadcast (capacity 4096) + per-venue monotonic seq counters (`AtomicU64`)
- `cache_writer` task: single subscriber that folds snapshots into Redis top-of-book (`r44:l2:top:{venue}:{market}`, 30s sliding TTL) and re-publishes events on per-market + firehose pub/sub channels
- Producers wired: `polymarket_ws` (snapshot on `Book`, delta on `PriceChange`), `polymarket_scanner`, `limitless_scanner`, `aerodrome_scanner`
- 4 passing smoke tests covering delivery, no-subscriber no-op, per-venue seq monotonicity, multi-subscriber fan-out

## Scope

Smart-router cutover to read the cache is deferred to a follow-up PR — this PR only lays the pipeline. No consumer behavior changes; the bus is additive.

## Test plan

- [x] `cargo test --test market_data_bus` — 4/4 pass
- [x] `cargo check --bin relay44-api` clean
- [ ] After deploy: `redis-cli KEYS 'r44:l2:top:*'` shows keys within ~1 minute of service start