### PR TITLE
smart_router: read top-of-book from L2 cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ docs/reports/*-20??????T??????Z.md
 .internal_assets_location
 .claude/
 .render-workspace-lock.json
+.codex-public-mirror/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1383,12 +1383,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
-name = "const-oid"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1663,7 +1657,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid 0.9.6",
+ "const-oid",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -1722,7 +1716,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid 0.9.6",
+ "const-oid",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -1734,7 +1728,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
  "block-buffer 0.12.0",
- "const-oid 0.10.2",
  "crypto-common 0.2.1",
  "ctutils",
 ]
@@ -2446,7 +2439,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac 0.12.1",
+ "hmac",
 ]
 
 [[package]]
@@ -2456,15 +2449,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
-]
-
-[[package]]
-name = "hmac"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
-dependencies = [
- "digest 0.11.2",
 ]
 
 [[package]]
@@ -2900,7 +2884,7 @@ dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
  "getrandom 0.2.17",
- "hmac 0.12.1",
+ "hmac",
  "js-sys",
  "p256",
  "p384",
@@ -4131,7 +4115,7 @@ dependencies = [
  "env_logger",
  "futures",
  "hex",
- "hmac 0.13.0",
+ "hmac",
  "http 1.4.0",
  "jsonwebtoken",
  "k256",
@@ -4148,7 +4132,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serial_test",
- "sha2 0.11.0",
+ "sha2 0.10.9",
  "sha3",
  "siwe",
  "sqlx",
@@ -4219,7 +4203,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac 0.12.1",
+ "hmac",
  "subtle",
 ]
 
@@ -4282,7 +4266,7 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid 0.9.6",
+ "const-oid",
  "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
@@ -4634,17 +4618,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.2",
 ]
 
 [[package]]
@@ -5777,7 +5750,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc905b200a95f2ea9146e43f2a7181e3aeb55de6bc12afb36462d00a3c7310de"
 dependencies = [
- "hmac 0.12.1",
+ "hmac",
  "pbkdf2",
  "sha2 0.10.9",
 ]
@@ -6544,7 +6517,7 @@ dependencies = [
  "generic-array",
  "hex",
  "hkdf",
- "hmac 0.12.1",
+ "hmac",
  "itoa",
  "log",
  "md-5",
@@ -6584,7 +6557,7 @@ dependencies = [
  "futures-util",
  "hex",
  "hkdf",
- "hmac 0.12.1",
+ "hmac",
  "home",
  "itoa",
  "log",

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -57,9 +57,9 @@ lazy_static = "1.4"
 rand = "0.10"
 
 # Cryptography
-sha2 = "0.11"
+sha2 = "0.10"
 sha3 = "0.10"
-hmac = "0.13"
+hmac = "0.12"
 hex = "0.4"
 aes-gcm = "0.10"
 k256 = { version = "0.13", features = ["ecdsa"] }

--- a/app/src/services/aerodrome_scanner.rs
+++ b/app/src/services/aerodrome_scanner.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::services::external::providers::aerodrome;
-use crate::services::market_data::{market_key, L2Event, L2Level, L2Payload, Venue};
+use crate::services::market_data::{L2Event, L2Level, L2Payload, Venue};
 use crate::AppState;
 
 // ── Scanner entry point ──
@@ -129,7 +129,7 @@ async fn run_scan(state: &AppState) -> Result<(i32, i32, i32), String> {
         let seq = state.market_data.next_seq(Venue::Aerodrome);
         state.market_data.emit(L2Event {
             venue: Venue::Aerodrome,
-            market_key: market_key(Venue::Aerodrome, &[pool_address]),
+            market_key: pool_address.to_string(),
             seq,
             observed_at: chrono::Utc::now(),
             payload: L2Payload::Snapshot {

--- a/app/src/services/limitless_scanner.rs
+++ b/app/src/services/limitless_scanner.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use crate::services::external::providers::limitless;
 use crate::services::external::types::ExternalMarketSnapshot;
-use crate::services::market_data::{market_key, L2Event, L2Level, L2Payload, Venue};
+use crate::services::market_data::{L2Event, L2Level, L2Payload, Venue};
 use crate::AppState;
 
 // ── Scanner entry point ──
@@ -150,7 +150,7 @@ async fn run_scan(state: &AppState) -> Result<(i32, i32, i32), String> {
             let seq = state.market_data.next_seq(Venue::Limitless);
             state.market_data.emit(L2Event {
                 venue: Venue::Limitless,
-                market_key: market_key(Venue::Limitless, &[slug, outcome]),
+                market_key: format!("{}:{}", slug, outcome),
                 seq,
                 observed_at: chrono::Utc::now(),
                 payload: L2Payload::Snapshot {

--- a/app/src/services/market_data/mod.rs
+++ b/app/src/services/market_data/mod.rs
@@ -82,13 +82,3 @@ pub struct L2Event {
     pub payload: L2Payload,
 }
 
-/// Canonical market-key format. Keep producers aligned with consumers.
-pub fn market_key(venue: Venue, parts: &[&str]) -> String {
-    let mut s = String::with_capacity(32);
-    s.push_str(venue.as_str());
-    for p in parts {
-        s.push(':');
-        s.push_str(p);
-    }
-    s
-}

--- a/app/src/services/smart_router.rs
+++ b/app/src/services/smart_router.rs
@@ -12,7 +12,52 @@ use std::time::Duration;
 
 use crate::services::external::types::ExternalMarketId;
 use crate::services::external::{self};
+use crate::services::market_data::{cache as l2_cache, TopOfBook, Venue};
 use crate::AppState;
+
+fn venue_for_provider(provider: &str) -> Option<Venue> {
+    match provider {
+        "polymarket" => Some(Venue::Polymarket),
+        "limitless" => Some(Venue::Limitless),
+        "aerodrome" => Some(Venue::Aerodrome),
+        _ => None,
+    }
+}
+
+fn cache_market_key(venue: Venue, provider_market_id: &str, outcome: &str) -> String {
+    match venue {
+        Venue::Limitless => format!("{}:{}", provider_market_id, outcome),
+        _ => provider_market_id.to_string(),
+    }
+}
+
+fn quote_from_top(link: &VenueLink, top: &TopOfBook) -> Option<VenueQuote> {
+    if top.best_bid.is_none() && top.best_ask.is_none() {
+        return None;
+    }
+    let best_bid = top.best_bid.as_ref().map(|l| l.price).filter(|&p| p > 0.0);
+    let best_ask = top.best_ask.as_ref().map(|l| l.price).filter(|&p| p > 0.0);
+    let fee_mult = link.fee_bps as f64 / 10_000.0;
+    Some(VenueQuote {
+        provider: link.provider.clone(),
+        provider_market_id: link.provider_market_id.clone(),
+        best_bid,
+        best_ask,
+        bid_depth_usdc: top
+            .best_bid
+            .as_ref()
+            .map(|l| l.price * l.size)
+            .unwrap_or(0.0),
+        ask_depth_usdc: top
+            .best_ask
+            .as_ref()
+            .map(|l| l.price * l.size)
+            .unwrap_or(0.0),
+        fee_bps: link.fee_bps,
+        effective_buy: best_ask.map(|p| p * (1.0 + fee_mult)),
+        effective_sell: best_bid.map(|p| p * (1.0 - fee_mult)),
+    })
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VenueQuote {
@@ -384,6 +429,25 @@ async fn fetch_venue_quote(
     link: &VenueLink,
     outcome: &str,
 ) -> Result<VenueQuote, String> {
+    if let Some(venue) = venue_for_provider(&link.provider) {
+        let key = cache_market_key(venue, &link.provider_market_id, outcome);
+        match l2_cache::read_top(&state.redis, venue, &key).await {
+            Ok(Some(top)) => {
+                if let Some(q) = quote_from_top(link, &top) {
+                    log::debug!(
+                        "smart_router cache hit {}:{} outcome={}",
+                        link.provider,
+                        key,
+                        outcome
+                    );
+                    return Ok(q);
+                }
+            }
+            Ok(None) => {}
+            Err(e) => log::debug!("l2 cache read failed ({}): {}", link.provider, e),
+        }
+    }
+
     let namespaced = format!("{}:{}", link.provider, link.provider_market_id);
     let market_id = ExternalMarketId::parse(&namespaced)
         .map_err(|e| format!("Bad market id: {}", e.message))?;


### PR DESCRIPTION
## Summary

First consumer wired to the market-data bus landed in #66. `smart_router::fetch_venue_quote` now tries the Redis top-of-book cache before the provider HTTP path:

- Cache hit → build a `VenueQuote` from `TopOfBook` (best bid/ask, single-level depth, effective buy/sell with fee).
- Cache miss or non-mapped provider → existing `external::fetch_orderbook` fallback, unchanged.

## Also in this PR

- Fix a bug in the #66 producers: Limitless and Aerodrome emitted `market_key` values prefixed with the venue, but `cache_writer` keys already include the venue — cache keys were landing as `r44:l2:top:limitless:limitless:slug:yes`. Changed producers to emit bare sub-ids.
- Drop the now-unused `market_key()` helper to prevent future misuse.
- Revert `sha2` 0.11 and `hmac` 0.13 bumps (merged in the dependabot batch earlier) — they broke `cargo build` on main because the crates changed their public APIs.
- Add `.codex-public-mirror/` to `.gitignore`.

## Test plan

- [x] `cargo check --bin relay44-api` clean
- [x] `cargo test --test market_data_bus` — 4/4 pass
- [ ] Prod canary: once deployed, watch for `smart_router cache hit` debug logs on a few venues; if none fire within 5 minutes, producer/consumer key mismatch remains