### PR TITLE
market_data: full-depth book cache + mirror producer

### DIFF
--- a/app/src/services/liquidity_mirror.rs
+++ b/app/src/services/liquidity_mirror.rs
@@ -13,8 +13,9 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::services::external::types::ExternalMarketId;
+use crate::services::external::types::{ExternalMarketId, ExternalOrderBookSnapshot};
 use crate::services::external::{self};
+use crate::services::market_data::{L2Event, L2Level, L2Payload, Venue};
 use crate::AppState;
 
 const DEFAULT_TICK_INTERVAL_SECS: u64 = 5;
@@ -189,6 +190,8 @@ async fn mirror_single_market(
             .await
             .map_err(|e| format!("Fetch yes orderbook: {}", e))?;
 
+    emit_snapshot_to_bus(state, &external_id, "yes", &yes_snapshot);
+
     let mut yes_bids: Vec<MirrorQuote> = Vec::new();
     let mut no_bids: Vec<MirrorQuote> = Vec::new();
     let mut total_depth = 0.0;
@@ -250,6 +253,82 @@ async fn mirror_single_market(
         total_depth_usdc: total_depth,
         updated_at: Utc::now().to_rfc3339(),
     })
+}
+
+fn bus_venue(provider: &crate::services::external::types::ExternalProvider) -> Venue {
+    use crate::services::external::types::ExternalProvider::*;
+    match provider {
+        Polymarket => Venue::Polymarket,
+        Limitless => Venue::Limitless,
+        Aerodrome => Venue::Aerodrome,
+    }
+}
+
+fn bus_market_key(
+    snapshot: &ExternalOrderBookSnapshot,
+    external_id: &ExternalMarketId,
+    outcome: &str,
+) -> String {
+    use crate::services::external::types::ExternalProvider::*;
+    match external_id.provider {
+        Polymarket => {
+            if !snapshot.provider_market_ref.is_empty() {
+                snapshot.provider_market_ref.clone()
+            } else {
+                external_id.value.clone()
+            }
+        }
+        Limitless => {
+            let base = if !snapshot.provider_market_ref.is_empty() {
+                snapshot.provider_market_ref.as_str()
+            } else {
+                external_id.value.as_str()
+            };
+            format!("{}:{}", base, outcome)
+        }
+        Aerodrome => external_id.value.clone(),
+    }
+}
+
+fn emit_snapshot_to_bus(
+    state: &AppState,
+    external_id: &ExternalMarketId,
+    outcome: &str,
+    snapshot: &ExternalOrderBookSnapshot,
+) {
+    let venue = bus_venue(&external_id.provider);
+    let market_key = bus_market_key(snapshot, external_id, outcome);
+    let bids: Vec<L2Level> = snapshot
+        .bids
+        .iter()
+        .map(|l| L2Level {
+            price: l.price,
+            size: l.quantity,
+        })
+        .collect();
+    let asks: Vec<L2Level> = snapshot
+        .asks
+        .iter()
+        .map(|l| L2Level {
+            price: l.price,
+            size: l.quantity,
+        })
+        .collect();
+    if bids.is_empty() && asks.is_empty() {
+        return;
+    }
+    let seq = state.market_data.next_seq(venue);
+    state.market_data.emit(L2Event {
+        venue,
+        market_key,
+        seq,
+        observed_at: Utc::now(),
+        payload: L2Payload::Snapshot {
+            bids,
+            asks,
+            last_trade: None,
+        },
+    });
 }
 
 /// Store mirror snapshot in Redis for the orderbook endpoint to read.

--- a/app/src/services/market_data/cache.rs
+++ b/app/src/services/market_data/cache.rs
@@ -1,8 +1,11 @@
-//! Redis-backed top-of-book cache for L2 events.
+//! Redis-backed caches for L2 events.
 //!
-//! Consumers that lag on the in-process bus reconcile by reading from here.
-//! Keys: `r44:l2:top:{venue}:{market_key}` with a 30s sliding TTL — a silent
-//! venue naturally expires so callers can fall back to direct fetches.
+//! Two views of the same stream:
+//! - `r44:l2:top:{venue}:{market_key}`  — best bid/ask, sized for hot-path reads.
+//! - `r44:l2:book:{venue}:{market_key}` — full snapshot (bids+asks), for depth consumers.
+//!
+//! Both have a 30s sliding TTL; a silent venue expires and callers fall back
+//! to direct fetches.
 
 use anyhow::Result;
 use chrono::{DateTime, Utc};
@@ -12,6 +15,7 @@ use super::{L2Level, Venue};
 use crate::services::RedisService;
 
 pub const TOP_OF_BOOK_TTL_SECS: u64 = 30;
+pub const FULL_BOOK_TTL_SECS: u64 = 30;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TopOfBook {
@@ -22,8 +26,21 @@ pub struct TopOfBook {
     pub observed_at: DateTime<Utc>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FullBook {
+    pub bids: Vec<L2Level>,
+    pub asks: Vec<L2Level>,
+    pub last_trade: Option<f64>,
+    pub seq: u64,
+    pub observed_at: DateTime<Utc>,
+}
+
 fn top_key(venue: Venue, market_key: &str) -> String {
     format!("r44:l2:top:{}:{}", venue.as_str(), market_key)
+}
+
+fn book_key(venue: Venue, market_key: &str) -> String {
+    format!("r44:l2:book:{}:{}", venue.as_str(), market_key)
 }
 
 pub async fn write_top(
@@ -43,4 +60,23 @@ pub async fn read_top(
     market_key: &str,
 ) -> Result<Option<TopOfBook>> {
     redis.get(&top_key(venue, market_key)).await
+}
+
+pub async fn write_book(
+    redis: &RedisService,
+    venue: Venue,
+    market_key: &str,
+    book: &FullBook,
+) -> Result<()> {
+    redis
+        .set(&book_key(venue, market_key), book, Some(FULL_BOOK_TTL_SECS))
+        .await
+}
+
+pub async fn read_book(
+    redis: &RedisService,
+    venue: Venue,
+    market_key: &str,
+) -> Result<Option<FullBook>> {
+    redis.get(&book_key(venue, market_key)).await
 }

--- a/app/src/services/market_data/cache_writer.rs
+++ b/app/src/services/market_data/cache_writer.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use log::{debug, warn};
 use tokio::sync::broadcast::error::RecvError;
 
-use super::{cache, L2Event, L2Payload, TopOfBook};
+use super::{cache, FullBook, L2Event, L2Payload, TopOfBook};
 use crate::AppState;
 
 pub fn spawn(state: Arc<AppState>) -> tokio::task::JoinHandle<()> {
@@ -36,6 +36,14 @@ async fn handle_event(state: &AppState, ev: Arc<L2Event>) {
             cache::write_top(&state.redis, ev.venue, &ev.market_key, &top).await
         {
             warn!("l2 cache write failed: {}", e);
+        }
+    }
+
+    if let Some(book) = fold_book(&ev) {
+        if let Err(e) =
+            cache::write_book(&state.redis, ev.venue, &ev.market_key, &book).await
+        {
+            warn!("l2 book cache write failed: {}", e);
         }
     }
 
@@ -67,5 +75,22 @@ fn fold_top(ev: &L2Event) -> Option<TopOfBook> {
             observed_at: ev.observed_at,
         }),
         L2Payload::Delta { .. } | L2Payload::Trade { .. } => None,
+    }
+}
+
+fn fold_book(ev: &L2Event) -> Option<FullBook> {
+    match &ev.payload {
+        L2Payload::Snapshot {
+            bids,
+            asks,
+            last_trade,
+        } if bids.len() > 1 || asks.len() > 1 => Some(FullBook {
+            bids: bids.clone(),
+            asks: asks.clone(),
+            last_trade: *last_trade,
+            seq: ev.seq,
+            observed_at: ev.observed_at,
+        }),
+        _ => None,
     }
 }

--- a/app/src/services/market_data/mod.rs
+++ b/app/src/services/market_data/mod.rs
@@ -14,7 +14,7 @@ pub mod cache;
 pub mod cache_writer;
 
 pub use bus::MarketDataBus;
-pub use cache::TopOfBook;
+pub use cache::{FullBook, TopOfBook};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]


### PR DESCRIPTION
## Summary
- extends `L2Cache` with a full-depth `FullBook` view (`r44:l2:book:{venue}:{market_key}`) alongside the existing top-of-book cache
- `liquidity_mirror` now emits the depth it already polls as an `L2Event::Snapshot` — turning the mirror loop into a producer so other consumers don't re-fetch the same orderbook
- `cache_writer` folds snapshots with depth>1 into the new book cache; single-level scanner emissions still only populate the top-of-book cache

## Why
piece #2 of PTE: smart_router cut over to top-of-book in #71. depth consumers (next: websocket hub, hedge-size logic) need 20 levels — this lands the cache path without changing any callers yet.

## Test plan
- [x] `cargo check --lib` clean
- [x] `cargo test --test market_data_bus` — 4/4 pass
- [ ] after merge: prod canary greps `r44:l2:book:polymarket:*` once `LIQUIDITY_MIRROR_ENABLED=true` on relay44-api