### PR TITLE
polymarket_scanner: emit l2 for every market with prices

### DIFF
--- a/app/src/services/polymarket_scanner.rs
+++ b/app/src/services/polymarket_scanner.rs
@@ -500,6 +500,15 @@ pub async fn run_scan(state: &AppState) -> Result<Vec<ScannedOpportunity>, Strin
         total_scanned += markets.len() as u32;
 
         for market in &markets {
+            if let Some((yes_token, no_token)) = extract_tokens(market) {
+                if let Some(p) = yes_token.price {
+                    emit_l2(state, yes_token.token_id.clone(), p);
+                }
+                if let Some(p) = no_token.price {
+                    emit_l2(state, no_token.token_id.clone(), p);
+                }
+            }
+
             if let Some(opp) = score_market(market) {
                 match opp.opportunity_type.as_str() {
                     t if t.starts_with("longshot") => longshots += 1,
@@ -510,8 +519,6 @@ pub async fn run_scan(state: &AppState) -> Result<Vec<ScannedOpportunity>, Strin
                 if let Err(e) = upsert_scanned_market(state, &opp).await {
                     warn!("Scanner: failed to persist {}: {}", opp.condition_id, e);
                 }
-                emit_l2(state, opp.yes_token_id.clone(), opp.yes_price);
-                emit_l2(state, opp.no_token_id.clone(), opp.no_price);
                 all_opportunities.push(opp);
             }
         }
@@ -656,28 +663,26 @@ pub fn spawn_scanner(state: Arc<AppState>) {
 
             match run_scan(&state).await {
                 Ok(opps) => {
-                    if !opps.is_empty() {
-                        let longshots = opps
-                            .iter()
-                            .filter(|o| o.opportunity_type.starts_with("longshot"))
-                            .count();
-                        let certs = opps
-                            .iter()
-                            .filter(|o| o.opportunity_type.starts_with("near_certainty"))
-                            .count();
-                        let spreads = opps
-                            .iter()
-                            .filter(|o| o.opportunity_type == "spread_capture")
-                            .count();
+                    let longshots = opps
+                        .iter()
+                        .filter(|o| o.opportunity_type.starts_with("longshot"))
+                        .count();
+                    let certs = opps
+                        .iter()
+                        .filter(|o| o.opportunity_type.starts_with("near_certainty"))
+                        .count();
+                    let spreads = opps
+                        .iter()
+                        .filter(|o| o.opportunity_type == "spread_capture")
+                        .count();
 
-                        info!(
-                            "PM scan: {} opportunities (longshot={}, near_cert={}, spread={})",
-                            opps.len(),
-                            longshots,
-                            certs,
-                            spreads
-                        );
-                    }
+                    info!(
+                        "PM scan: {} opportunities (longshot={}, near_cert={}, spread={})",
+                        opps.len(),
+                        longshots,
+                        certs,
+                        spreads
+                    );
                 }
                 Err(e) => {
                     warn!("PM scan error: {}", e);


### PR DESCRIPTION
## Summary
- emit L2 per market up-front (outside score_market) so the r44:l2:top:* cache actually populates
- unconditionally log scan summary so we can see activity when zero opportunities score

Cache was empty because the only emit calls were inside `score_market`'s `Some` branch, which the `liquidity >= 100` filter rejects for the vast majority of markets.

## Test plan
- [x] `cargo test --test market_data_bus`
- [ ] after deploy, `redis-cli --scan --pattern 'r44:l2:top:polymarket:*'` returns keys within one scan cycle