### PR TITLE
probability_alert: enrich alerts + silence dust-market flood

### DIFF
--- a/app/src/services/probability_alert.rs
+++ b/app/src/services/probability_alert.rs
@@ -4,6 +4,12 @@
 //! (venue, market_key), and pushes a Telegram message when a fresh snapshot
 //! moves by more than `PROB_ALERT_THRESHOLD_PCT`. Each market is on a
 //! per-market cooldown so a rapidly-jittery book can't spam the channel.
+//!
+//! Alerts are enriched with question, deep link, category, liquidity and
+//! 24h volume by joining against the scanner's own market tables.
+//! `PROB_ALERT_MIN_LIQUIDITY_USD` suppresses alerts on known-thin markets
+//! without dropping alerts for markets whose metadata isn't in the scanner
+//! tables yet.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -49,11 +55,16 @@ pub fn spawn(state: Arc<AppState>) {
             .and_then(|v| v.parse::<u64>().ok())
             .unwrap_or(DEFAULT_COOLDOWN_SECS),
     );
+    let min_liquidity_usd = std::env::var("PROB_ALERT_MIN_LIQUIDITY_USD")
+        .ok()
+        .and_then(|v| v.parse::<f64>().ok())
+        .unwrap_or(0.0);
 
     info!(
-        "Starting Telegram probability alerts (threshold={}%, cooldown={}s)",
+        "Starting Telegram probability alerts (threshold={}%, cooldown={}s, min_liquidity=${})",
         threshold_pct,
-        cooldown.as_secs()
+        cooldown.as_secs(),
+        min_liquidity_usd,
     );
 
     let mut rx = state.market_data.subscribe();
@@ -71,6 +82,7 @@ pub fn spawn(state: Arc<AppState>) {
                         &tg,
                         threshold_pct,
                         cooldown,
+                        min_liquidity_usd,
                         &mut last_price,
                         &mut last_alert,
                         &ev,
@@ -89,11 +101,20 @@ pub fn spawn(state: Arc<AppState>) {
     });
 }
 
+struct MarketContext {
+    question: String,
+    url: Option<String>,
+    category: Option<String>,
+    liquidity_usd: Option<f64>,
+    volume_24h_usd: Option<f64>,
+}
+
 async fn handle_event(
     state: &AppState,
     tg: &TelegramClient,
     threshold_pct: f64,
     cooldown: Duration,
+    min_liquidity_usd: f64,
     last_price: &mut HashMap<String, f64>,
     last_alert: &mut HashMap<String, Instant>,
     ev: &L2Event,
@@ -125,13 +146,27 @@ async fn handle_event(
             return;
         }
     }
+
+    let ctx = lookup_context(state, ev.venue, &ev.market_key).await;
+
+    if min_liquidity_usd > 0.0 {
+        if let Some(liq) = ctx.as_ref().and_then(|c| c.liquidity_usd) {
+            if liq < min_liquidity_usd {
+                return;
+            }
+        }
+    }
+
     last_alert.insert(key, Instant::now());
 
-    let question = lookup_question(state, ev.venue, &ev.market_key)
-        .await
-        .unwrap_or_else(|| format!("{}:{}", ev.venue.as_str(), truncate(&ev.market_key, 12)));
-
-    let text = format_alert(&question, prev_price, price, delta_pct);
+    let text = format_alert(
+        ctx.as_ref(),
+        ev.venue,
+        &ev.market_key,
+        prev_price,
+        price,
+        delta_pct,
+    );
     if let Err(e) = tg.send(&text).await {
         warn!("telegram send failed: {}", e);
     }
@@ -152,21 +187,77 @@ fn cache_key(venue: Venue, market_key: &str) -> String {
     format!("{}:{}", venue.as_str(), market_key)
 }
 
-async fn lookup_question(state: &AppState, venue: Venue, market_key: &str) -> Option<String> {
-    if venue != Venue::Polymarket {
-        return None;
+async fn lookup_context(
+    state: &AppState,
+    venue: Venue,
+    market_key: &str,
+) -> Option<MarketContext> {
+    match venue {
+        Venue::Polymarket => lookup_polymarket(state, market_key).await,
+        Venue::Limitless => lookup_limitless(state, market_key).await,
+        _ => None,
     }
+}
+
+async fn lookup_polymarket(state: &AppState, token_id: &str) -> Option<MarketContext> {
     let pool = state.db.pool();
-    let row: Option<(String,)> = sqlx::query_as(
-        "SELECT question FROM polymarket_scanned_markets \
+    let row: Option<(String, String, String, Option<f64>, Option<f64>)> = sqlx::query_as(
+        "SELECT question, slug, category, \
+                liquidity_usdc::double precision, volume_usdc::double precision \
+         FROM polymarket_scanned_markets \
          WHERE yes_token_id = $1 OR no_token_id = $1 LIMIT 1",
     )
-    .bind(market_key)
+    .bind(token_id)
     .fetch_optional(pool)
     .await
     .ok()
     .flatten();
-    row.map(|r| r.0)
+
+    row.map(|(question, slug, category, liquidity_usd, volume_24h_usd)| MarketContext {
+        question,
+        url: (!slug.is_empty()).then(|| format!("https://polymarket.com/event/{}", slug)),
+        category: normalize_category(&category),
+        liquidity_usd,
+        volume_24h_usd,
+    })
+}
+
+async fn lookup_limitless(state: &AppState, market_key: &str) -> Option<MarketContext> {
+    // Limitless market_key is "{slug}:{outcome}" where outcome is yes|no.
+    // rsplit_once tolerates colons inside the slug itself.
+    let slug = market_key
+        .rsplit_once(':')
+        .map(|(prefix, _)| prefix)
+        .unwrap_or(market_key);
+
+    let pool = state.db.pool();
+    let row: Option<(String, Option<String>, Option<f64>, Option<f64>)> = sqlx::query_as(
+        "SELECT question, category, liquidity_usdc, volume_usdc \
+         FROM limitless_scanned_markets \
+         WHERE slug = $1 LIMIT 1",
+    )
+    .bind(slug)
+    .fetch_optional(pool)
+    .await
+    .ok()
+    .flatten();
+
+    row.map(|(question, category, liquidity_usd, volume_24h_usd)| MarketContext {
+        question,
+        url: Some(format!("https://limitless.exchange/markets/{}", slug)),
+        category: category.as_deref().and_then(normalize_category),
+        liquidity_usd,
+        volume_24h_usd,
+    })
+}
+
+fn normalize_category(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("unknown") {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
 }
 
 fn truncate(s: &str, n: usize) -> String {
@@ -177,14 +268,60 @@ fn truncate(s: &str, n: usize) -> String {
     }
 }
 
-fn format_alert(question: &str, prev: f64, curr: f64, delta_pct: f64) -> String {
+fn format_alert(
+    ctx: Option<&MarketContext>,
+    venue: Venue,
+    market_key: &str,
+    prev: f64,
+    curr: f64,
+    delta_pct: f64,
+) -> String {
     let arrow = if delta_pct > 0.0 { "↑" } else { "↓" };
-    format!(
-        "{arrow} {question}\n{:.1}¢ → {:.1}¢  ({:+.1}%)",
-        prev * 100.0,
-        curr * 100.0,
-        delta_pct
-    )
+    let question = ctx
+        .map(|c| c.question.clone())
+        .unwrap_or_else(|| format!("{}:{}", venue.as_str(), truncate(market_key, 12)));
+
+    let mut lines = vec![
+        format!("{arrow} {question}"),
+        format!(
+            "{:.1}¢ → {:.1}¢  ({:+.1}%)",
+            prev * 100.0,
+            curr * 100.0,
+            delta_pct
+        ),
+    ];
+
+    if let Some(c) = ctx {
+        let mut meta: Vec<String> = Vec::new();
+        if let Some(cat) = &c.category {
+            meta.push(cat.clone());
+        }
+        if let Some(liq) = c.liquidity_usd {
+            meta.push(format!("liq {}", format_money(liq)));
+        }
+        if let Some(vol) = c.volume_24h_usd {
+            meta.push(format!("vol {}", format_money(vol)));
+        }
+        if !meta.is_empty() {
+            lines.push(meta.join(" · "));
+        }
+        if let Some(url) = &c.url {
+            lines.push(url.clone());
+        }
+    }
+
+    lines.join("\n")
+}
+
+fn format_money(v: f64) -> String {
+    let abs = v.abs();
+    if abs >= 1_000_000.0 {
+        format!("${:.1}M", v / 1_000_000.0)
+    } else if abs >= 1_000.0 {
+        format!("${:.1}k", v / 1_000.0)
+    } else {
+        format!("${:.0}", v)
+    }
 }
 
 struct TelegramClient {
@@ -237,9 +374,20 @@ impl TelegramClient {
 mod tests {
     use super::*;
 
+    fn ctx_full() -> MarketContext {
+        MarketContext {
+            question: "Will X happen?".to_string(),
+            url: Some("https://polymarket.com/event/will-x".to_string()),
+            category: Some("politics".to_string()),
+            liquidity_usd: Some(125_000.0),
+            volume_24h_usd: Some(3_400_000.0),
+        }
+    }
+
     #[test]
     fn format_includes_question_and_delta() {
-        let s = format_alert("Will X happen?", 0.10, 0.18, 80.0);
+        let c = ctx_full();
+        let s = format_alert(Some(&c), Venue::Polymarket, "tok", 0.10, 0.18, 80.0);
         assert!(s.contains("Will X happen?"));
         assert!(s.contains("10.0¢"));
         assert!(s.contains("18.0¢"));
@@ -248,7 +396,56 @@ mod tests {
 
     #[test]
     fn format_down_arrow_for_negative() {
-        let s = format_alert("Q", 0.50, 0.40, -20.0);
+        let c = ctx_full();
+        let s = format_alert(Some(&c), Venue::Polymarket, "tok", 0.50, 0.40, -20.0);
         assert!(s.contains("↓"));
+    }
+
+    #[test]
+    fn format_includes_enrichment_when_ctx_present() {
+        let c = ctx_full();
+        let s = format_alert(Some(&c), Venue::Polymarket, "tok", 0.10, 0.18, 80.0);
+        assert!(s.contains("politics"));
+        assert!(s.contains("liq $125.0k"));
+        assert!(s.contains("vol $3.4M"));
+        assert!(s.contains("https://polymarket.com/event/will-x"));
+    }
+
+    #[test]
+    fn format_falls_back_to_venue_market_key_without_ctx() {
+        let s = format_alert(None, Venue::Limitless, "some-long-market-slug", 0.10, 0.15, 50.0);
+        assert!(s.contains("limitless:"));
+        assert!(s.contains("50.0%") || s.contains("+50.0%"));
+    }
+
+    #[test]
+    fn format_omits_missing_enrichment_fields() {
+        let c = MarketContext {
+            question: "Q".to_string(),
+            url: None,
+            category: None,
+            liquidity_usd: None,
+            volume_24h_usd: None,
+        };
+        let s = format_alert(Some(&c), Venue::Polymarket, "tok", 0.10, 0.15, 50.0);
+        assert!(s.contains("Q"));
+        assert!(!s.contains("liq "));
+        assert!(!s.contains("vol "));
+        assert!(!s.contains("http"));
+    }
+
+    #[test]
+    fn money_formatter_ranges() {
+        assert_eq!(format_money(42.0), "$42");
+        assert_eq!(format_money(4_200.0), "$4.2k");
+        assert_eq!(format_money(4_200_000.0), "$4.2M");
+    }
+
+    #[test]
+    fn normalize_category_drops_unknown_and_empty() {
+        assert_eq!(normalize_category("politics"), Some("politics".to_string()));
+        assert_eq!(normalize_category("Unknown"), None);
+        assert_eq!(normalize_category("  "), None);
+        assert_eq!(normalize_category(""), None);
     }
 }

--- a/app/src/services/probability_alert.rs
+++ b/app/src/services/probability_alert.rs
@@ -24,7 +24,8 @@ use crate::AppState;
 
 const DEFAULT_THRESHOLD_PCT: f64 = 5.0;
 const DEFAULT_COOLDOWN_SECS: u64 = 300;
-const MIN_PRICE_FOR_ALERT: f64 = 0.01;
+const DEFAULT_MIN_PRICE: f64 = 0.05;
+const HARD_MIN_PRICE: f64 = 0.01;
 
 pub fn spawn(state: Arc<AppState>) {
     let enabled = std::env::var("TELEGRAM_ALERTS_ENABLED")
@@ -59,12 +60,18 @@ pub fn spawn(state: Arc<AppState>) {
         .ok()
         .and_then(|v| v.parse::<f64>().ok())
         .unwrap_or(0.0);
+    let min_price = std::env::var("PROB_ALERT_MIN_PRICE")
+        .ok()
+        .and_then(|v| v.parse::<f64>().ok())
+        .unwrap_or(DEFAULT_MIN_PRICE)
+        .max(HARD_MIN_PRICE);
 
     info!(
-        "Starting Telegram probability alerts (threshold={}%, cooldown={}s, min_liquidity=${})",
+        "Starting Telegram probability alerts (threshold={}%, cooldown={}s, min_liquidity=${}, min_price={}¢)",
         threshold_pct,
         cooldown.as_secs(),
         min_liquidity_usd,
+        (min_price * 100.0) as i32,
     );
 
     let mut rx = state.market_data.subscribe();
@@ -83,6 +90,7 @@ pub fn spawn(state: Arc<AppState>) {
                         threshold_pct,
                         cooldown,
                         min_liquidity_usd,
+                        min_price,
                         &mut last_price,
                         &mut last_alert,
                         &ev,
@@ -115,6 +123,7 @@ async fn handle_event(
     threshold_pct: f64,
     cooldown: Duration,
     min_liquidity_usd: f64,
+    min_price: f64,
     last_price: &mut HashMap<String, f64>,
     last_alert: &mut HashMap<String, Instant>,
     ev: &L2Event,
@@ -122,7 +131,7 @@ async fn handle_event(
     let Some(price) = current_price(&ev.payload) else {
         return;
     };
-    if price < MIN_PRICE_FOR_ALERT {
+    if price < HARD_MIN_PRICE {
         return;
     }
 
@@ -132,7 +141,14 @@ async fn handle_event(
     let Some(prev_price) = prev else {
         return;
     };
-    if prev_price < MIN_PRICE_FOR_ALERT {
+    if prev_price < HARD_MIN_PRICE {
+        return;
+    }
+
+    // Dust-market gate: if either end of the move is below the configured
+    // min price, this is almost certainly a penny bouncing around rather
+    // than a meaningful probability shift.
+    if price < min_price || prev_price < min_price {
         return;
     }
 


### PR DESCRIPTION
## Summary
- Enrich Telegram probability alerts with market context: question, URL, category, liquidity, 24h volume.
- Add `PROB_ALERT_MIN_LIQUIDITY_USD` env to gate alerts on thin books (unknown liquidity still passes through).
- Add `PROB_ALERT_MIN_PRICE` env (default 0.05) — skips alerts when prev or current price is below the floor. This is the real fix for the dust-market alert flood we saw live.
- Polymarket and Limitless URL/metadata lookups via existing scanner tables.

## Test plan
- [ ] Unit tests pass (7 new)
- [ ] On Render: re-enable `TELEGRAM_ALERTS_ENABLED=true` and confirm no flood from sub-5c markets
- [ ] Confirm alert format renders question + URL + meta line in Telegram