### PR TITLE
tokenomics: add Trade $RELAY CTA

### DIFF
--- a/web/src/app/tokenomics/page.tsx
+++ b/web/src/app/tokenomics/page.tsx
@@ -38,7 +38,7 @@ export default function TokenomicsPage() {
   const orderBook = prod.contracts.orderBook!;
 
   return (
-    <div className="container mx-auto max-w-5xl px-4 py-10">
+    <div className="py-10">
       <StructuredData
         data={[
           buildWebPageStructuredData({
@@ -68,6 +68,22 @@ export default function TokenomicsPage() {
           lock RELAY to capture a cut of protocol revenue — all on Base, all
           open source.
         </p>
+        <div className="flex flex-wrap gap-3 pt-2">
+          <a
+            href="https://www.geckoterminal.com/base/pools/0xc9b0297827af885f115621b30fdfb13318e75f0649d1cdb45fe71f3cc22fff91"
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex h-10 items-center border border-accent bg-accent px-5 text-xs uppercase tracking-widest text-text-inverse transition-colors hover:bg-accent-hover"
+          >
+            Trade $RELAY ↗
+          </a>
+          <Link
+            href="/staking"
+            className="inline-flex h-10 items-center border border-border bg-bg-secondary px-5 text-xs uppercase tracking-widest text-text-primary transition-colors hover:border-border-hover"
+          >
+            Stake $RELAY
+          </Link>
+        </div>
       </div>
 
       {/* ---------------- Token summary ---------------- */}


### PR DESCRIPTION
## Summary
- Add \"Trade \$RELAY\" button on \`/tokenomics\` linking to the GeckoTerminal pool page.
- Keep the existing \"Stake \$RELAY\" CTA next to it.
- Drop the narrow \`max-w-5xl\` outer wrapper so the page inherits PageShell's 1400 container.

## Test plan
- [ ] \`/tokenomics\` renders both buttons above the fold
- [ ] Trade button opens GeckoTerminal in a new tab
- [ ] Stake button still routes to \`/staking\`