### PR TITLE
layout: align page widths to footer (1400px + sm:px-8)

### DIFF
--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -70,7 +70,7 @@ export default function AdminDashboard() {
   if (!address) {
     return (
       <PageShell>
-        <div className="container mx-auto max-w-6xl px-4 py-8">
+        <div className="py-8">
           <Card>
             <CardContent className="flex h-40 items-center justify-center text-text-secondary">
               Connect your wallet to access admin dashboard
@@ -84,7 +84,7 @@ export default function AdminDashboard() {
   if (!isAdmin) {
     return (
       <PageShell>
-        <div className="container mx-auto max-w-6xl px-4 py-8">
+        <div className="py-8">
           <Card>
             <CardContent className="flex h-40 flex-col items-center justify-center gap-2">
               <p className="text-ask font-medium">Access denied</p>
@@ -100,7 +100,7 @@ export default function AdminDashboard() {
 
   return (
     <PageShell>
-      <div className="container mx-auto max-w-6xl space-y-8 px-4 py-8">
+      <div className="space-y-8 py-8">
         <div className="flex items-center justify-between">
           <h1 className="text-2xl font-bold text-text-primary">Admin Dashboard</h1>
           <Badge variant="accent">Admin Mode</Badge>

--- a/web/src/app/context-graph/page.tsx
+++ b/web/src/app/context-graph/page.tsx
@@ -30,7 +30,7 @@ export default function ContextGraphPage() {
 
   return (
     <PageShell>
-      <div className="container mx-auto max-w-6xl px-4 py-8 space-y-6">
+      <div className="py-8 space-y-6">
         <div className="space-y-2">
           <h1 className="text-3xl font-bold">Context Graph</h1>
           <p className="text-text-secondary">

--- a/web/src/app/distribution/DistributionPageClient.tsx
+++ b/web/src/app/distribution/DistributionPageClient.tsx
@@ -46,7 +46,7 @@ export default function DistributionPageClient() {
 
       {/* Sticky filter bar */}
       <div className="top-header sticky z-40 bg-bg-primary border-b border-border">
-        <div className="max-w-[1400px] mx-auto px-4 sm:px-6">
+        <div className="max-w-[1400px] mx-auto px-4 sm:px-8">
           <div className="flex items-center gap-4 py-3 overflow-x-auto scrollbar-hide">
             {/* Status tabs */}
             <div className="flex items-center gap-1 flex-shrink-0">
@@ -89,7 +89,7 @@ export default function DistributionPageClient() {
         </div>
       </div>
 
-      <div className="max-w-[1400px] mx-auto px-4 sm:px-6 py-6">
+      <div className="max-w-[1400px] mx-auto px-4 sm:px-8 py-6">
         {/* Header + stats */}
         <div className="mb-6">
           <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between mb-4">

--- a/web/src/app/distribution/[id]/page.tsx
+++ b/web/src/app/distribution/[id]/page.tsx
@@ -185,7 +185,7 @@ export default function DistributionMarketPage() {
 
   return (
     <PageShell>
-      <div className="max-w-[1400px] mx-auto px-4 sm:px-6 py-6 pb-24 lg:pb-6">
+      <div className="py-6 pb-24 lg:pb-6">
         {/* Header */}
         <div className="flex flex-col sm:flex-row items-start justify-between gap-3 mb-6">
           <div className="flex-1 min-w-0">

--- a/web/src/app/distribution/create/page.tsx
+++ b/web/src/app/distribution/create/page.tsx
@@ -160,7 +160,8 @@ export default function CreateDistributionMarketPage() {
 
   return (
     <PageShell>
-      <div className="container mx-auto max-w-2xl px-4 py-8">
+      <div className="py-8">
+        <div className="mx-auto max-w-2xl">
         <h1 className="text-lg font-medium text-text-primary mb-2">
           Create Distribution Market
         </h1>
@@ -352,6 +353,7 @@ export default function CreateDistributionMarketPage() {
               Cancel
             </Button>
           </div>
+        </div>
         </div>
       </div>
     </PageShell>

--- a/web/src/app/docs/page.tsx
+++ b/web/src/app/docs/page.tsx
@@ -191,7 +191,7 @@ const mcpTools = [
 
 export default function DocsPage() {
   return (
-    <div className="mx-auto max-w-7xl px-4 pb-8 sm:px-6 lg:px-8">
+    <div className="pb-8">
       <div className="lg:grid lg:grid-cols-[minmax(0,1fr)_14rem] lg:gap-12">
         {/* ---- Main content ---- */}
         <div className="min-w-0 max-w-3xl">

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -86,7 +86,7 @@
 
   @media (min-width: 640px) {
     .container-app {
-      padding-inline: 1.5rem;
+      padding-inline: 2rem;
     }
   }
 
@@ -98,7 +98,7 @@
 
   @media (min-width: 640px) {
     .shell-frame {
-      padding-inline: 1.5rem;
+      padding-inline: 2rem;
     }
   }
 

--- a/web/src/app/hackathon/[id]/page.tsx
+++ b/web/src/app/hackathon/[id]/page.tsx
@@ -19,8 +19,10 @@ export default function HackathonDetailPage() {
   if (isLoading) {
     return (
       <PageShell>
-        <div className="container mx-auto max-w-4xl px-4 py-8">
-          <div className="h-64 bg-bg-secondary animate-pulse border border-border" />
+        <div className="py-8">
+          <div className="mx-auto max-w-3xl">
+            <div className="h-64 bg-bg-secondary animate-pulse border border-border" />
+          </div>
         </div>
       </PageShell>
     );
@@ -29,8 +31,10 @@ export default function HackathonDetailPage() {
   if (!hackathon) {
     return (
       <PageShell>
-        <div className="container mx-auto max-w-4xl px-4 py-8 text-center text-text-secondary">
-          Hackathon not found.
+        <div className="py-8">
+          <div className="mx-auto max-w-3xl text-center text-text-secondary">
+            Hackathon not found.
+          </div>
         </div>
       </PageShell>
     );
@@ -45,7 +49,8 @@ export default function HackathonDetailPage() {
 
   return (
     <PageShell>
-      <div className="container mx-auto max-w-4xl px-4 py-8 space-y-6">
+      <div className="py-8">
+        <div className="mx-auto max-w-3xl space-y-6">
         {/* Header */}
         <div className="space-y-3">
           <div className="flex items-center gap-3 flex-wrap">
@@ -108,6 +113,7 @@ export default function HackathonDetailPage() {
 
         {/* PnL Chart */}
         <HackathonPnlChart hackathonId={hackathon.id} />
+        </div>
       </div>
     </PageShell>
   );

--- a/web/src/app/hackathon/admin/page.tsx
+++ b/web/src/app/hackathon/admin/page.tsx
@@ -37,12 +37,14 @@ export default function HackathonAdminPage() {
   if (!address) {
     return (
       <PageShell>
-        <div className="container mx-auto max-w-4xl px-4 py-8">
-          <Card>
-            <CardContent className="py-8 text-center text-text-secondary">
-              Connect your wallet to access admin panel.
-            </CardContent>
-          </Card>
+        <div className="py-8">
+          <div className="mx-auto max-w-3xl">
+            <Card>
+              <CardContent className="py-8 text-center text-text-secondary">
+                Connect your wallet to access admin panel.
+              </CardContent>
+            </Card>
+          </div>
         </div>
       </PageShell>
     );
@@ -51,12 +53,14 @@ export default function HackathonAdminPage() {
   if (!isAdmin) {
     return (
       <PageShell>
-        <div className="container mx-auto max-w-4xl px-4 py-8">
-          <Card>
-            <CardContent className="py-8 text-center text-text-secondary">
-              Access denied. Admin wallet required.
-            </CardContent>
-          </Card>
+        <div className="py-8">
+          <div className="mx-auto max-w-3xl">
+            <Card>
+              <CardContent className="py-8 text-center text-text-secondary">
+                Access denied. Admin wallet required.
+              </CardContent>
+            </Card>
+          </div>
         </div>
       </PageShell>
     );
@@ -135,11 +139,12 @@ export default function HackathonAdminPage() {
 
   return (
     <PageShell>
-      <div className="container mx-auto max-w-4xl px-4 py-8 space-y-6">
-        <div className="flex items-center justify-between">
-          <h1 className="text-2xl font-bold">Hackathon Admin</h1>
-          <Badge variant="accent">Admin Mode</Badge>
-        </div>
+      <div className="py-8">
+        <div className="mx-auto max-w-3xl space-y-6">
+          <div className="flex items-center justify-between">
+            <h1 className="text-2xl font-bold">Hackathon Admin</h1>
+            <Badge variant="accent">Admin Mode</Badge>
+          </div>
 
         {/* Create form */}
         <Card>
@@ -278,6 +283,7 @@ export default function HackathonAdminPage() {
             )}
           </CardContent>
         </Card>
+        </div>
       </div>
     </PageShell>
   );

--- a/web/src/app/hackathon/page.tsx
+++ b/web/src/app/hackathon/page.tsx
@@ -17,7 +17,7 @@ export default function HackathonPage() {
 
   return (
     <PageShell>
-      <div className="container mx-auto max-w-6xl px-4 py-8 space-y-8">
+      <div className="py-8 space-y-8">
         {/* Hero */}
         <div className="space-y-4">
           <div className="flex items-center gap-3">

--- a/web/src/app/how-it-works/page.tsx
+++ b/web/src/app/how-it-works/page.tsx
@@ -65,7 +65,7 @@ export default function HowItWorksPage() {
           ]),
         ]}
       />
-      <div className="mx-auto max-w-5xl py-2 sm:py-4">
+      <div className="py-2 sm:py-4">
         <div className="mb-8 max-w-3xl">
           <h1 className="text-3xl font-semibold text-text-primary sm:text-4xl">How It Works</h1>
           <p className="mt-4 text-base leading-7 text-text-secondary">

--- a/web/src/app/identity/page.tsx
+++ b/web/src/app/identity/page.tsx
@@ -159,7 +159,8 @@ export default function IdentityPage() {
 
   return (
     <PageShell>
-      <div className="container mx-auto max-w-2xl px-4 py-8 space-y-8">
+      <div className="py-8">
+        <div className="mx-auto max-w-2xl space-y-8">
         <div>
           <h1 className="text-2xl font-bold">Agent Identity</h1>
           <p className="text-sm text-text-secondary mt-1">
@@ -345,6 +346,7 @@ export default function IdentityPage() {
             </Card>
           </div>
         )}
+        </div>
       </div>
     </PageShell>
   );

--- a/web/src/app/leaderboard/page.tsx
+++ b/web/src/app/leaderboard/page.tsx
@@ -6,7 +6,7 @@ import { LeaderboardTable } from '@/components/leaderboard/LeaderboardTable';
 export default function LeaderboardPage() {
   return (
     <PageShell>
-      <div className="container mx-auto max-w-6xl px-4 py-8 space-y-8">
+      <div className="py-8 space-y-8">
         <div className="space-y-2">
           <h1 className="text-3xl font-bold">Leaderboard</h1>
           <p className="text-text-secondary">

--- a/web/src/app/legal/disclaimer/page.tsx
+++ b/web/src/app/legal/disclaimer/page.tsx
@@ -30,7 +30,7 @@ export default function DisclaimerPage() {
           ]),
         ]}
       />
-      <div className="container mx-auto px-4 pb-8 max-w-4xl">
+      <div className="pb-8 mx-auto max-w-3xl">
         <h1 className="text-3xl font-bold text-text-primary mb-8">Risk Disclaimer</h1>
 
         <div className="prose prose-invert max-w-none space-y-6 text-text-secondary">

--- a/web/src/app/legal/page.tsx
+++ b/web/src/app/legal/page.tsx
@@ -49,20 +49,22 @@ export default function LegalPage() {
           }),
         ]}
       />
-      <div className="container mx-auto px-4 pb-8 max-w-4xl">
-        <h1 className="text-3xl font-bold text-text-primary mb-8">Legal</h1>
+      <div className="pb-8">
+        <div className="mx-auto max-w-4xl">
+          <h1 className="text-3xl font-bold text-text-primary mb-8">Legal</h1>
 
-        <div className="grid gap-4">
-          {legalPages.map((page) => (
-            <Link key={page.href} href={page.href}>
-              <Card hover>
-                <CardHeader>
-                  <CardTitle>{page.title}</CardTitle>
-                  <CardDescription>{page.description}</CardDescription>
-                </CardHeader>
-              </Card>
-            </Link>
-          ))}
+          <div className="grid gap-4">
+            {legalPages.map((page) => (
+              <Link key={page.href} href={page.href}>
+                <Card hover>
+                  <CardHeader>
+                    <CardTitle>{page.title}</CardTitle>
+                    <CardDescription>{page.description}</CardDescription>
+                  </CardHeader>
+                </Card>
+              </Link>
+            ))}
+          </div>
         </div>
       </div>
     </>

--- a/web/src/app/legal/privacy/page.tsx
+++ b/web/src/app/legal/privacy/page.tsx
@@ -30,7 +30,7 @@ export default function PrivacyPolicyPage() {
           ]),
         ]}
       />
-      <div className="container mx-auto px-4 pb-8 max-w-4xl">
+      <div className="pb-8 mx-auto max-w-3xl">
         <h1 className="text-3xl font-bold text-text-primary mb-8">Privacy Policy</h1>
 
         <div className="prose prose-invert max-w-none space-y-6 text-text-secondary">

--- a/web/src/app/legal/terms/page.tsx
+++ b/web/src/app/legal/terms/page.tsx
@@ -30,7 +30,7 @@ export default function TermsOfServicePage() {
           ]),
         ]}
       />
-      <div className="container mx-auto px-4 pb-8 max-w-4xl">
+      <div className="pb-8 mx-auto max-w-3xl">
         <h1 className="text-3xl font-bold text-text-primary mb-8">Terms of Service</h1>
 
         <div className="prose prose-invert max-w-none space-y-6 text-text-secondary">

--- a/web/src/app/markets/MarketsClient.tsx
+++ b/web/src/app/markets/MarketsClient.tsx
@@ -112,7 +112,7 @@ export default function MarketsClient({
     <div className="min-h-screen pt-header">
       <Header />
       <div className="top-header sticky z-40 bg-bg-primary border-b border-border">
-        <div className="max-w-[1400px] mx-auto px-4 sm:px-6">
+        <div className="max-w-[1400px] mx-auto px-4 sm:px-8">
           <div className="flex items-center gap-4 py-3 overflow-x-auto scrollbar-hide">
             <div className="flex items-center gap-1 flex-shrink-0">
               <button
@@ -196,7 +196,7 @@ export default function MarketsClient({
         </div>
       </div>
 
-      <div className="max-w-[1400px] mx-auto px-4 sm:px-6 py-6">
+      <div className="max-w-[1400px] mx-auto px-4 sm:px-8 py-6">
         <div className="mb-6 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <div className="space-y-1">
             <h1 className="text-2xl font-semibold text-text-primary">

--- a/web/src/app/markets/create/page.tsx
+++ b/web/src/app/markets/create/page.tsx
@@ -32,8 +32,9 @@ export default async function CreateMarketPage({
 
   return (
     <PageShell>
-      <div className="container mx-auto max-w-2xl px-4 py-8">
-        <CreateMarketForm
+      <div className="py-8">
+        <div className="mx-auto max-w-2xl">
+          <CreateMarketForm
           draftSlide={draftSlide}
           initialDraftId={draftId}
           initialQuestion={firstParam(params.question)}
@@ -41,8 +42,9 @@ export default async function CreateMarketPage({
           initialCategory={firstParam(params.category)}
           initialResolutionSource={firstParam(params.resolutionSource)}
           initialCustomSource={firstParam(params.customSource)}
-          initialTradingEnd={firstParam(params.tradingEnd)}
-        />
+            initialTradingEnd={firstParam(params.tradingEnd)}
+          />
+        </div>
       </div>
     </PageShell>
   );

--- a/web/src/app/profile/[wallet]/page.tsx
+++ b/web/src/app/profile/[wallet]/page.tsx
@@ -26,7 +26,7 @@ export default function ProfilePage({ params }: Props) {
 
   return (
     <PageShell>
-      <div className="container mx-auto max-w-6xl px-4 py-8 space-y-8">
+      <div className="py-8 space-y-8">
         <div className="flex items-start justify-between gap-4">
           <div className="flex-1">
             <ProfileHeader wallet={wallet} />

--- a/web/src/app/referrals/page.tsx
+++ b/web/src/app/referrals/page.tsx
@@ -255,26 +255,28 @@ export default function ReferralsPage() {
 
   return (
     <PageShell>
-      <div className="container mx-auto max-w-4xl px-4 py-8">
-        <h1 className="text-2xl font-bold text-text-primary mb-2">Referrals</h1>
-        <p className="mb-6 max-w-2xl text-sm leading-6 text-text-secondary">
-          Invite friends to Relay44 and earn rewards when they start trading.
-          Share your unique referral link and track your progress below.
-        </p>
+      <div className="py-8">
+        <div className="mx-auto max-w-3xl">
+          <h1 className="text-2xl font-bold text-text-primary mb-2">Referrals</h1>
+          <p className="mb-6 text-sm leading-6 text-text-secondary">
+            Invite friends to Relay44 and earn rewards when they start trading.
+            Share your unique referral link and track your progress below.
+          </p>
 
-        {!isAuthenticated ? (
-          <Card>
-            <p className="text-text-secondary text-center py-8">
-              Connect your wallet to access the referral program.
-            </p>
-          </Card>
-        ) : (
-          <>
-            <ReferralLinkSection />
-            <ApplyCodeSection />
-            <StatsSection />
-          </>
-        )}
+          {!isAuthenticated ? (
+            <Card>
+              <p className="text-text-secondary text-center py-8">
+                Connect your wallet to access the referral program.
+              </p>
+            </Card>
+          ) : (
+            <>
+              <ReferralLinkSection />
+              <ApplyCodeSection />
+              <StatsSection />
+            </>
+          )}
+        </div>
       </div>
     </PageShell>
   );

--- a/web/src/app/screener/ScreenerClient.tsx
+++ b/web/src/app/screener/ScreenerClient.tsx
@@ -116,7 +116,7 @@ export default function ScreenerClient() {
 
   return (
     <PageShell>
-      <div className="container mx-auto max-w-6xl px-4 py-8 space-y-6">
+      <div className="py-8 space-y-6">
         <div className="space-y-2">
           <h1 className="text-xl font-semibold">Screener</h1>
           <p className="text-sm text-text-secondary">

--- a/web/src/app/settings/notifications/page.tsx
+++ b/web/src/app/settings/notifications/page.tsx
@@ -12,8 +12,10 @@ export const metadata = buildPageMetadata({
 export default function NotificationSettingsPage() {
   return (
     <PageShell>
-      <div className="mx-auto max-w-2xl py-2 sm:py-4">
-        <NotificationSettings />
+      <div className="py-2 sm:py-4">
+        <div className="mx-auto max-w-2xl">
+          <NotificationSettings />
+        </div>
       </div>
     </PageShell>
   );

--- a/web/src/app/signals/SignalsPageClient.tsx
+++ b/web/src/app/signals/SignalsPageClient.tsx
@@ -125,7 +125,7 @@ export default function SignalsPageClient() {
 
   return (
     <PageShell>
-      <div className="container mx-auto max-w-6xl px-4 py-8 space-y-8">
+      <div className="py-8 space-y-8">
         <div className="flex flex-wrap items-end justify-between gap-4">
           <div className="space-y-2">
             <h1 className="text-xl font-semibold">Signals</h1>

--- a/web/src/app/staking/page.tsx
+++ b/web/src/app/staking/page.tsx
@@ -6,23 +6,25 @@ import { StakingPanel } from '@/components/staking';
 export default function StakingPage() {
   return (
     <PageShell>
-      <div className="container mx-auto max-w-4xl px-4 py-8">
-        <h1 className="text-2xl font-bold text-text-primary mb-2">Stake $RELAY</h1>
-        <p className="mb-4 max-w-2xl text-sm leading-6 text-text-secondary">
-          Lock RELAY tokens to earn staking rewards, unlock tiered fee discounts,
-          and gain priority access to platform features.
-        </p>
-        <p className="mb-8 max-w-2xl text-xs text-text-muted">
-          See{' '}
-          <a
-            href="/tokenomics"
-            className="text-text-secondary underline-offset-2 hover:text-text-primary hover:underline"
-          >
-            /tokenomics
-          </a>{' '}
-          for the full fee flow, reward allocation, and roadmap.
-        </p>
-        <StakingPanel />
+      <div className="py-8">
+        <div className="mx-auto max-w-3xl">
+          <h1 className="text-2xl font-bold text-text-primary mb-2">Stake $RELAY</h1>
+          <p className="mb-4 text-sm leading-6 text-text-secondary">
+            Lock RELAY tokens to earn staking rewards, unlock tiered fee discounts,
+            and gain priority access to platform features.
+          </p>
+          <p className="mb-8 text-xs text-text-muted">
+            See{' '}
+            <a
+              href="/tokenomics"
+              className="text-text-secondary underline-offset-2 hover:text-text-primary hover:underline"
+            >
+              /tokenomics
+            </a>{' '}
+            for the full fee flow, reward allocation, and roadmap.
+          </p>
+          <StakingPanel />
+        </div>
       </div>
     </PageShell>
   );

--- a/web/src/app/swarm/[swarmId]/page.tsx
+++ b/web/src/app/swarm/[swarmId]/page.tsx
@@ -13,11 +13,10 @@ export default function SwarmPage({ params }: Props) {
 
   return (
     <PageShell>
-      <div
-        className="container mx-auto max-w-3xl px-4 py-4"
-        style={{ height: 'calc(100vh - 8rem)' }}
-      >
-        <SwarmPanel swarmId={swarmId} />
+      <div className="py-4" style={{ height: 'calc(100vh - 8rem)' }}>
+        <div className="mx-auto max-w-3xl h-full">
+          <SwarmPanel swarmId={swarmId} />
+        </div>
       </div>
     </PageShell>
   );

--- a/web/src/app/wallet/page.tsx
+++ b/web/src/app/wallet/page.tsx
@@ -6,14 +6,16 @@ import { WalletPanel } from "@/components/wallet";
 export default function WalletPage() {
   return (
     <PageShell>
-      <div className="container mx-auto max-w-4xl px-4 py-8">
-        <h1 className="text-2xl font-bold text-text-primary mb-6">Wallet</h1>
-        <p className="mb-6 max-w-2xl text-sm leading-6 text-text-secondary">
-          Review vault balance, transaction history, and transfer actions. Live
-          write actions still depend on wallet sign-in, runtime mode, and
-          route-level availability.
-        </p>
-        <WalletPanel />
+      <div className="py-8">
+        <div className="mx-auto max-w-3xl">
+          <h1 className="text-2xl font-bold text-text-primary mb-6">Wallet</h1>
+          <p className="mb-6 text-sm leading-6 text-text-secondary">
+            Review vault balance, transaction history, and transfer actions. Live
+            write actions still depend on wallet sign-in, runtime mode, and
+            route-level availability.
+          </p>
+          <WalletPanel />
+        </div>
       </div>
     </PageShell>
   );

--- a/web/src/components/admin/SecurityAuditPageClient.tsx
+++ b/web/src/components/admin/SecurityAuditPageClient.tsx
@@ -13,7 +13,7 @@ export function SecurityAuditPageClient() {
   if (!address) {
     return (
       <PageShell>
-        <div className="container mx-auto max-w-6xl px-4 py-8">
+        <div className="py-8">
           <Card>
             <CardContent className="flex h-40 items-center justify-center text-text-secondary">
               Connect your wallet to access security audit notes
@@ -27,7 +27,7 @@ export function SecurityAuditPageClient() {
   if (!isAdmin) {
     return (
       <PageShell>
-        <div className="container mx-auto max-w-6xl px-4 py-8">
+        <div className="py-8">
           <Card>
             <CardContent className="flex h-40 flex-col items-center justify-center gap-2">
               <p className="text-ask font-medium">Access denied</p>
@@ -43,7 +43,7 @@ export function SecurityAuditPageClient() {
 
   return (
     <PageShell>
-      <div className="container mx-auto px-4 py-8">
+      <div className="py-8">
         <h1 className="mb-6 text-2xl font-bold text-text-primary">Security Audit Preparation</h1>
         <SecurityAuditChecklist />
       </div>


### PR DESCRIPTION
## Summary
- Bump \`container-app\` / \`shell-frame\` padding to \`sm:px-8\` so the outer chrome matches the footer's 1400px + 2rem padding shell.
- Drop per-page narrow \`max-w-4xl/5xl/6xl\` outer wrappers on dashboard pages (admin, leaderboard, signals, screener, context-graph, hackathon, profile, docs, how-it-works, SecurityAudit). They now inherit the 1400 shell.
- Nest \`max-w-3xl\` or \`max-w-2xl\` readers inside the 1400 shell on prose-heavy (legal, wallet, staking, referrals, hackathon admin, hackathon [id]) and form-heavy pages (markets/create, identity, settings/notifications, swarm/[swarmId], distribution/create) so reading / form widths stay comfortable.
- Distribution + markets 1400 shells updated from \`sm:px-6\` → \`sm:px-8\` to match.

28 files touched.

## Test plan
- [ ] Every page's outer edges line up with the footer's columns on desktop (1400px cap + 2rem gutters)
- [ ] Prose pages (legal/terms, legal/privacy, legal/disclaimer) still read comfortably — not stretched full-width
- [ ] Form pages (identity, markets/create, distribution/create) keep form inputs at readable widths
- [ ] Mobile padding unchanged (\`px-4\`)