### PR TITLE
alerts: phase 1 polish - shared format helpers liquidity gate html escape

### DIFF
--- a/app/src/services/cross_venue_arb.rs
+++ b/app/src/services/cross_venue_arb.rs
@@ -7,17 +7,23 @@
 //! `CROSS_VENUE_ARB_THRESHOLD` (absolute probability, default 0.05 = 5¢) and
 //! both sides are fresh, we push a Telegram alert. Each (pair, outcome) has
 //! an independent cooldown so a flapping book can't spam the channel.
+//!
+//! Message layout is HTML and uses the shared helpers in `telegram_format` so
+//! this alerter stays consistent with `probability_alert` and
+//! `new_market_alert`.
 
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use log::{info, warn};
-use serde::Serialize;
 use tokio::sync::broadcast::error::RecvError;
 use tokio::sync::RwLock;
 
 use super::market_data::{L2Event, L2Payload, Venue};
+use super::telegram_format::{
+    format_deep_link, format_metadata_row, html_escape, TelegramClient,
+};
 use crate::AppState;
 
 const DEFAULT_THRESHOLD: f64 = 0.05;
@@ -42,9 +48,19 @@ impl Outcome {
     }
 }
 
+#[derive(Clone, Debug, Default)]
+struct PairMeta {
+    question: String,
+    pm_slug: Option<String>,
+    lim_slug: Option<String>,
+    category: Option<String>,
+    liquidity_usd: Option<f64>,
+    volume_24h_usd: Option<f64>,
+}
+
 struct PairLookup {
     by_venue_key: HashMap<(Venue, String), (String, Outcome)>,
-    questions: HashMap<String, String>,
+    meta: HashMap<String, PairMeta>,
 }
 
 pub fn spawn(state: Arc<AppState>) {
@@ -79,7 +95,7 @@ pub fn spawn(state: Arc<AppState>) {
 
     let lookup: Arc<RwLock<PairLookup>> = Arc::new(RwLock::new(PairLookup {
         by_venue_key: HashMap::new(),
-        questions: HashMap::new(),
+        meta: HashMap::new(),
     }));
 
     {
@@ -192,15 +208,15 @@ async fn handle_event(
         _ => return,
     };
 
-    let question = {
+    let meta = {
         let l = lookup.read().await;
-        l.questions
-            .get(&pair_id)
-            .cloned()
-            .unwrap_or_else(|| pair_id.clone())
+        l.meta.get(&pair_id).cloned().unwrap_or_else(|| PairMeta {
+            question: pair_id.clone(),
+            ..Default::default()
+        })
     };
 
-    let text = format_alert(&question, outcome, pm_price, lim_price);
+    let text = format_alert(&meta, outcome, pm_price, lim_price);
     if let Err(e) = tg.send(&text).await {
         warn!("telegram send failed (cross-venue arb): {}", e);
     }
@@ -245,9 +261,26 @@ async fn load_pairs(state: &AppState) -> Result<PairLookup, String> {
     .await
     .map_err(|e| format!("load_pairs venue-keys: {}", e))?;
 
-    let questions_rows: Vec<(String, String)> = sqlx::query_as(
+    // Per-pair metadata from the Polymarket side (question, slug, category,
+    // liquidity, volume). We deliberately prefer PM's metadata here because
+    // it's historically more complete — Limitless categories are often
+    // unset or "unknown".
+    let meta_rows: Vec<(
+        String,
+        String,
+        Option<String>,
+        Option<String>,
+        Option<f64>,
+        Option<f64>,
+    )> = sqlx::query_as(
         r#"
-        SELECT pm.market_slug, psm.question
+        SELECT
+            pm.market_slug,
+            psm.question,
+            psm.slug,
+            psm.category,
+            psm.liquidity_usdc::double precision,
+            psm.volume_usdc::double precision
         FROM market_venue_links pm
         JOIN polymarket_scanned_markets psm
             ON psm.condition_id = pm.provider_market_id
@@ -256,7 +289,18 @@ async fn load_pairs(state: &AppState) -> Result<PairLookup, String> {
     )
     .fetch_all(pool)
     .await
-    .map_err(|e| format!("load_pairs questions: {}", e))?;
+    .map_err(|e| format!("load_pairs meta: {}", e))?;
+
+    let limitless_slugs: Vec<(String, String)> = sqlx::query_as(
+        r#"
+        SELECT market_slug, provider_market_id
+        FROM market_venue_links
+        WHERE provider = 'limitless' AND active = TRUE
+        "#,
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(|e| format!("load_pairs lim slugs: {}", e))?;
 
     let mut by_venue_key = HashMap::new();
     for (market_slug, lim_slug, yes_tok, no_tok) in rows {
@@ -278,28 +322,80 @@ async fn load_pairs(state: &AppState) -> Result<PairLookup, String> {
         );
     }
 
-    let mut questions = HashMap::new();
-    for (slug, q) in questions_rows {
-        questions.insert(slug, q);
+    let mut meta: HashMap<String, PairMeta> = HashMap::new();
+    for (market_slug, question, pm_slug, category, liquidity, volume) in meta_rows {
+        meta.insert(
+            market_slug,
+            PairMeta {
+                question,
+                pm_slug: pm_slug.filter(|s| !s.is_empty()),
+                lim_slug: None,
+                category: category.and_then(|c| {
+                    let t = c.trim();
+                    if t.is_empty() || t.eq_ignore_ascii_case("unknown") {
+                        None
+                    } else {
+                        Some(t.to_string())
+                    }
+                }),
+                liquidity_usd: liquidity,
+                volume_24h_usd: volume,
+            },
+        );
+    }
+    for (market_slug, lim_slug) in limitless_slugs {
+        meta.entry(market_slug)
+            .or_insert_with(PairMeta::default)
+            .lim_slug = Some(lim_slug);
     }
 
-    Ok(PairLookup {
-        by_venue_key,
-        questions,
-    })
+    Ok(PairLookup { by_venue_key, meta })
 }
 
-fn format_alert(question: &str, outcome: Outcome, pm: f64, lim: f64) -> String {
+fn format_alert(meta: &PairMeta, outcome: Outcome, pm: f64, lim: f64) -> String {
     let edge_cents = (pm - lim).abs() * 100.0;
     let direction = if pm > lim { "PM↑ LIM↓" } else { "PM↓ LIM↑" };
-    format!(
-        "⚡ Cross-venue arb: {question}\n{} {}: Polymarket {:.1}¢  |  Limitless {:.1}¢  (Δ {:.1}¢)",
+
+    let mut lines: Vec<String> = Vec::new();
+    // Arb header uses a neutral venue label since the signal spans both.
+    lines.push("<b>\u{2696}\u{FE0F} Cross-venue arb — PM vs LIM</b>".to_string());
+    lines.push(format!("<i>{}</i>", html_escape(&meta.question)));
+    lines.push(format!(
+        "{} {}: Polymarket {:.1}¢ | Limitless {:.1}¢ (Δ {:.1}¢)",
         outcome.as_str(),
         direction,
         pm * 100.0,
         lim * 100.0,
         edge_cents
-    )
+    ));
+
+    let meta_row = format_metadata_row(
+        meta.liquidity_usd,
+        meta.volume_24h_usd,
+        meta.category.as_deref(),
+    );
+    if !meta_row.is_empty() {
+        lines.push(meta_row);
+    }
+
+    // Dual footer: one link per venue so readers can jump to whichever side
+    // they're more comfortable trading on.
+    let mut link_parts: Vec<String> = Vec::new();
+    if let Some(slug) = &meta.pm_slug {
+        if let Some(link) = format_deep_link("polymarket", slug) {
+            link_parts.push(link);
+        }
+    }
+    if let Some(slug) = &meta.lim_slug {
+        if let Some(link) = format_deep_link("limitless", slug) {
+            link_parts.push(link);
+        }
+    }
+    if !link_parts.is_empty() {
+        lines.push(link_parts.join(" | "));
+    }
+
+    lines.join("\n")
 }
 
 fn env_bool(key: &str, default: bool) -> bool {
@@ -323,60 +419,25 @@ fn env_f64(key: &str, default: f64) -> f64 {
         .unwrap_or(default)
 }
 
-struct TelegramClient {
-    bot_token: String,
-    chat_id: String,
-    http: reqwest::Client,
-}
-
-impl TelegramClient {
-    fn new(bot_token: String, chat_id: String) -> Self {
-        Self {
-            bot_token,
-            chat_id,
-            http: reqwest::Client::builder()
-                .timeout(Duration::from_secs(5))
-                .build()
-                .expect("reqwest client"),
-        }
-    }
-
-    async fn send(&self, text: &str) -> Result<(), String> {
-        #[derive(Serialize)]
-        struct Payload<'a> {
-            chat_id: &'a str,
-            text: &'a str,
-            disable_web_page_preview: bool,
-        }
-        let url = format!("https://api.telegram.org/bot{}/sendMessage", self.bot_token);
-        let resp = self
-            .http
-            .post(&url)
-            .json(&Payload {
-                chat_id: &self.chat_id,
-                text,
-                disable_web_page_preview: true,
-            })
-            .send()
-            .await
-            .map_err(|e| format!("request: {}", e))?;
-        if !resp.status().is_success() {
-            let code = resp.status();
-            let body = resp.text().await.unwrap_or_default();
-            return Err(format!("telegram {}: {}", code, body));
-        }
-        Ok(())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::services::market_data::L2Level;
 
+    fn meta(question: &str) -> PairMeta {
+        PairMeta {
+            question: question.to_string(),
+            pm_slug: Some("pm-slug".to_string()),
+            lim_slug: Some("lim-slug".to_string()),
+            category: Some("politics".to_string()),
+            liquidity_usd: Some(50_000.0),
+            volume_24h_usd: Some(1_200_000.0),
+        }
+    }
+
     #[test]
     fn format_shows_question_outcome_and_edge() {
-        let s = format_alert("Will BTC hit 100k by EOY?", Outcome::Yes, 0.42, 0.37);
+        let s = format_alert(&meta("Will BTC hit 100k by EOY?"), Outcome::Yes, 0.42, 0.37);
         assert!(s.contains("Will BTC hit 100k by EOY?"));
         assert!(s.contains("YES"));
         assert!(s.contains("42.0¢"));
@@ -385,11 +446,37 @@ mod tests {
     }
 
     #[test]
+    fn format_header_identifies_pm_vs_lim() {
+        let s = format_alert(&meta("Q"), Outcome::Yes, 0.50, 0.40);
+        assert!(s.contains("<b>"));
+        assert!(s.contains("Cross-venue arb"));
+        assert!(s.contains("PM vs LIM"));
+    }
+
+    #[test]
     fn format_marks_direction() {
-        let up = format_alert("Q", Outcome::No, 0.60, 0.45);
+        let up = format_alert(&meta("Q"), Outcome::No, 0.60, 0.45);
         assert!(up.contains("PM↑ LIM↓"));
-        let dn = format_alert("Q", Outcome::No, 0.30, 0.45);
+        let dn = format_alert(&meta("Q"), Outcome::No, 0.30, 0.45);
         assert!(dn.contains("PM↓ LIM↑"));
+    }
+
+    #[test]
+    fn format_includes_metadata_and_dual_links() {
+        let s = format_alert(&meta("Q"), Outcome::Yes, 0.50, 0.40);
+        assert!(s.contains("Liquidity: $50.0k"));
+        assert!(s.contains("24h vol: $1.2M"));
+        assert!(s.contains("Category: politics"));
+        assert!(s.contains("polymarket.com/market/pm-slug"));
+        assert!(s.contains("limitless.exchange/markets/lim-slug"));
+        assert!(s.contains("Open on Polymarket"));
+        assert!(s.contains("Open on Limitless"));
+    }
+
+    #[test]
+    fn format_html_escapes_question() {
+        let s = format_alert(&meta("A<B>&C"), Outcome::Yes, 0.50, 0.40);
+        assert!(s.contains("A&lt;B&gt;&amp;C"));
     }
 
     #[test]

--- a/app/src/services/cross_venue_arb.rs
+++ b/app/src/services/cross_venue_arb.rs
@@ -467,7 +467,7 @@ mod tests {
         assert!(s.contains("Liquidity: $50.0k"));
         assert!(s.contains("24h vol: $1.2M"));
         assert!(s.contains("Category: politics"));
-        assert!(s.contains("polymarket.com/market/pm-slug"));
+        assert!(s.contains("polymarket.com/event/pm-slug"));
         assert!(s.contains("limitless.exchange/markets/lim-slug"));
         assert!(s.contains("Open on Polymarket"));
         assert!(s.contains("Open on Limitless"));

--- a/app/src/services/cross_venue_arb.rs
+++ b/app/src/services/cross_venue_arb.rs
@@ -344,9 +344,7 @@ async fn load_pairs(state: &AppState) -> Result<PairLookup, String> {
         );
     }
     for (market_slug, lim_slug) in limitless_slugs {
-        meta.entry(market_slug)
-            .or_insert_with(PairMeta::default)
-            .lim_slug = Some(lim_slug);
+        meta.entry(market_slug).or_default().lim_slug = Some(lim_slug);
     }
 
     Ok(PairLookup { by_venue_key, meta })

--- a/app/src/services/mod.rs
+++ b/app/src/services/mod.rs
@@ -31,6 +31,7 @@ pub mod polymarket_ws;
 pub mod portfolio_snapshot;
 pub mod probability_alert;
 pub mod telegram_commands;
+pub mod telegram_format;
 pub mod provider_rails;
 pub mod pyth;
 pub mod redis;

--- a/app/src/services/new_market_alert.rs
+++ b/app/src/services/new_market_alert.rs
@@ -365,7 +365,7 @@ mod tests {
         assert!(s.contains("New market"));
         assert!(s.contains("Polymarket"));
         assert!(s.contains("<i>Will BTC hit 100k?</i>"));
-        assert!(s.contains("polymarket.com/market/example-slug"));
+        assert!(s.contains("polymarket.com/event/example-slug"));
         assert!(s.contains("Open on Polymarket"));
         assert!(s.contains("kw:btc"));
     }

--- a/app/src/services/new_market_alert.rs
+++ b/app/src/services/new_market_alert.rs
@@ -6,6 +6,10 @@
 //! `NEW_MARKET_CATEGORIES` filter matches — we push a Telegram alert. One
 //! cooldown per keyword-match prevents the same keyword from re-alerting on a
 //! backlog of near-simultaneous launches.
+//!
+//! Message layout is HTML and uses the shared helpers in `telegram_format` so
+//! this alerter stays consistent with `probability_alert` and
+//! `cross_venue_arb`.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -13,8 +17,10 @@ use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Utc};
 use log::{info, warn};
-use serde::Serialize;
 
+use super::telegram_format::{
+    format_alert_header, format_deep_link, format_metadata_row, html_escape, TelegramClient,
+};
 use crate::AppState;
 
 const DEFAULT_POLL_SECS: u64 = 60;
@@ -114,6 +120,8 @@ struct NewMarket {
     question: String,
     category: String,
     slug: String,
+    liquidity_usd: Option<f64>,
+    volume_24h_usd: Option<f64>,
     created_at: DateTime<Utc>,
 }
 
@@ -148,8 +156,17 @@ async fn fetch_new_polymarket(
     let pool = state.db.pool();
     let cutoff = cursor.unwrap_or_else(|| Utc::now() - chrono::Duration::minutes(5));
 
-    let rows: Vec<(String, String, String, DateTime<Utc>)> = sqlx::query_as(
-        "SELECT question, COALESCE(category, 'unknown'), COALESCE(slug, ''), created_at \
+    let rows: Vec<(
+        String,
+        String,
+        String,
+        Option<f64>,
+        Option<f64>,
+        DateTime<Utc>,
+    )> = sqlx::query_as(
+        "SELECT question, COALESCE(category, 'unknown'), COALESCE(slug, ''), \
+                liquidity_usdc::double precision, volume_usdc::double precision, \
+                created_at \
          FROM polymarket_scanned_markets \
          WHERE created_at > $1 AND active = TRUE \
          ORDER BY created_at ASC \
@@ -162,13 +179,17 @@ async fn fetch_new_polymarket(
 
     Ok(rows
         .into_iter()
-        .map(|(question, category, slug, created_at)| NewMarket {
-            venue: "polymarket",
-            question,
-            category,
-            slug,
-            created_at,
-        })
+        .map(
+            |(question, category, slug, liquidity_usd, volume_24h_usd, created_at)| NewMarket {
+                venue: "polymarket",
+                question,
+                category,
+                slug,
+                liquidity_usd,
+                volume_24h_usd,
+                created_at,
+            },
+        )
         .collect())
 }
 
@@ -179,8 +200,16 @@ async fn fetch_new_limitless(
     let pool = state.db.pool();
     let cutoff = cursor.unwrap_or_else(|| Utc::now() - chrono::Duration::minutes(5));
 
-    let rows: Vec<(String, String, String, DateTime<Utc>)> = sqlx::query_as(
-        "SELECT question, COALESCE(category, 'unknown'), slug, created_at \
+    let rows: Vec<(
+        String,
+        String,
+        String,
+        Option<f64>,
+        Option<f64>,
+        DateTime<Utc>,
+    )> = sqlx::query_as(
+        "SELECT question, COALESCE(category, 'unknown'), slug, \
+                liquidity_usdc, volume_usdc, created_at \
          FROM limitless_scanned_markets \
          WHERE created_at > $1 AND active = TRUE \
          ORDER BY created_at ASC \
@@ -193,13 +222,17 @@ async fn fetch_new_limitless(
 
     Ok(rows
         .into_iter()
-        .map(|(question, category, slug, created_at)| NewMarket {
-            venue: "limitless",
-            question,
-            category,
-            slug,
-            created_at,
-        })
+        .map(
+            |(question, category, slug, liquidity_usd, volume_24h_usd, created_at)| NewMarket {
+                venue: "limitless",
+                question,
+                category,
+                slug,
+                liquidity_usd,
+                volume_24h_usd,
+                created_at,
+            },
+        )
         .collect())
 }
 
@@ -247,28 +280,21 @@ fn match_hit(watchlist: &[String], categories: &[String], m: &NewMarket) -> Opti
 }
 
 fn format_alert(m: &NewMarket, reason: &str) -> String {
-    let link = market_link(m);
-    format!(
-        "🆕 New market ({venue}, {category})\n{question}\nmatch: {reason}{link}",
-        venue = m.venue,
-        category = m.category,
-        question = m.question,
-        reason = reason,
-        link = link
-            .map(|l| format!("\n{}", l))
-            .unwrap_or_default(),
-    )
-}
+    let mut lines: Vec<String> = Vec::new();
+    lines.push(format_alert_header("\u{1F195}", "New market", m.venue));
+    lines.push(format!("<i>{}</i>", html_escape(&m.question)));
+    lines.push(format!("match: <code>{}</code>", html_escape(reason)));
 
-fn market_link(m: &NewMarket) -> Option<String> {
-    if m.slug.is_empty() {
-        return None;
+    let meta = format_metadata_row(m.liquidity_usd, m.volume_24h_usd, Some(&m.category));
+    if !meta.is_empty() {
+        lines.push(meta);
     }
-    match m.venue {
-        "polymarket" => Some(format!("https://polymarket.com/event/{}", m.slug)),
-        "limitless" => Some(format!("https://limitless.exchange/markets/{}", m.slug)),
-        _ => None,
+
+    if let Some(link) = format_deep_link(m.venue, &m.slug) {
+        lines.push(link);
     }
+
+    lines.join("\n")
 }
 
 fn parse_csv_lower(raw: String) -> Vec<String> {
@@ -292,52 +318,6 @@ fn env_u64(key: &str, default: u64) -> u64 {
         .unwrap_or(default)
 }
 
-struct TelegramClient {
-    bot_token: String,
-    chat_id: String,
-    http: reqwest::Client,
-}
-
-impl TelegramClient {
-    fn new(bot_token: String, chat_id: String) -> Self {
-        Self {
-            bot_token,
-            chat_id,
-            http: reqwest::Client::builder()
-                .timeout(Duration::from_secs(5))
-                .build()
-                .expect("reqwest client"),
-        }
-    }
-
-    async fn send(&self, text: &str) -> Result<(), String> {
-        #[derive(Serialize)]
-        struct Payload<'a> {
-            chat_id: &'a str,
-            text: &'a str,
-            disable_web_page_preview: bool,
-        }
-        let url = format!("https://api.telegram.org/bot{}/sendMessage", self.bot_token);
-        let resp = self
-            .http
-            .post(&url)
-            .json(&Payload {
-                chat_id: &self.chat_id,
-                text,
-                disable_web_page_preview: true,
-            })
-            .send()
-            .await
-            .map_err(|e| format!("request: {}", e))?;
-        if !resp.status().is_success() {
-            let code = resp.status();
-            let body = resp.text().await.unwrap_or_default();
-            return Err(format!("telegram {}: {}", code, body));
-        }
-        Ok(())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -348,6 +328,8 @@ mod tests {
             question: question.to_string(),
             category: category.to_string(),
             slug: "example-slug".to_string(),
+            liquidity_usd: Some(10_000.0),
+            volume_24h_usd: Some(250_000.0),
             created_at: Utc::now(),
         }
     }
@@ -376,14 +358,35 @@ mod tests {
     }
 
     #[test]
-    fn alert_body_contains_question_and_link() {
+    fn alert_body_contains_question_header_and_link() {
         let m = sample("Will BTC hit 100k?", "crypto");
         let s = format_alert(&m, "kw:btc");
-        assert!(s.contains("🆕 New market"));
-        assert!(s.contains("polymarket"));
-        assert!(s.contains("Will BTC hit 100k?"));
-        assert!(s.contains("polymarket.com/event/example-slug"));
+        assert!(s.contains("<b>"));
+        assert!(s.contains("New market"));
+        assert!(s.contains("Polymarket"));
+        assert!(s.contains("<i>Will BTC hit 100k?</i>"));
+        assert!(s.contains("polymarket.com/market/example-slug"));
+        assert!(s.contains("Open on Polymarket"));
         assert!(s.contains("kw:btc"));
+    }
+
+    #[test]
+    fn alert_includes_metadata_row() {
+        let m = sample("Will BTC hit 100k?", "crypto");
+        let s = format_alert(&m, "kw:btc");
+        assert!(s.contains("Liquidity: $10.0k"));
+        assert!(s.contains("24h vol: $250.0k"));
+        assert!(s.contains("Category: crypto"));
+    }
+
+    #[test]
+    fn alert_html_escapes_question_and_reason() {
+        let mut m = sample("Will <X> happen?", "crypto");
+        m.slug = "slug".to_string();
+        let s = format_alert(&m, "kw:<evil>");
+        assert!(s.contains("Will &lt;X&gt; happen?"));
+        assert!(s.contains("kw:&lt;evil&gt;"));
+        assert!(!s.contains("<evil>"));
     }
 
     #[test]
@@ -392,6 +395,17 @@ mod tests {
         m.slug.clear();
         let s = format_alert(&m, "kw:btc");
         assert!(!s.contains("polymarket.com"));
+    }
+
+    #[test]
+    fn alert_limitless_uses_limitless_link() {
+        let mut m = sample("Will BTC hit 100k?", "crypto");
+        m.venue = "limitless";
+        m.slug = "lim-slug".to_string();
+        let s = format_alert(&m, "kw:btc");
+        assert!(s.contains("limitless.exchange/markets/lim-slug"));
+        assert!(s.contains("Open on Limitless"));
+        assert!(s.contains("Limitless"));
     }
 
     #[test]

--- a/app/src/services/probability_alert.rs
+++ b/app/src/services/probability_alert.rs
@@ -6,20 +6,27 @@
 //! per-market cooldown so a rapidly-jittery book can't spam the channel.
 //!
 //! Alerts are enriched with question, deep link, category, liquidity and
-//! 24h volume by joining against the scanner's own market tables.
+//! 24h volume by joining against the scanner's own market tables
+//! (`polymarket_scanned_markets`, `limitless_scanned_markets`).
 //! `PROB_ALERT_MIN_LIQUIDITY_USD` suppresses alerts on known-thin markets
 //! without dropping alerts for markets whose metadata isn't in the scanner
 //! tables yet.
+//!
+//! Message layout is HTML and goes through the shared helpers in
+//! `telegram_format` so this alerter stays visually consistent with
+//! `cross_venue_arb` and `new_market_alert`.
 
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use log::{info, warn};
-use serde::Serialize;
 use tokio::sync::broadcast::error::RecvError;
 
 use super::market_data::{L2Event, L2Payload, Venue};
+use super::telegram_format::{
+    format_alert_header, format_deep_link, format_metadata_row, html_escape, TelegramClient,
+};
 use crate::AppState;
 
 const DEFAULT_THRESHOLD_PCT: f64 = 5.0;
@@ -111,7 +118,7 @@ pub fn spawn(state: Arc<AppState>) {
 
 struct MarketContext {
     question: String,
-    url: Option<String>,
+    slug: Option<String>,
     category: Option<String>,
     liquidity_usd: Option<f64>,
     volume_24h_usd: Option<f64>,
@@ -165,12 +172,8 @@ async fn handle_event(
 
     let ctx = lookup_context(state, ev.venue, &ev.market_key).await;
 
-    if min_liquidity_usd > 0.0 {
-        if let Some(liq) = ctx.as_ref().and_then(|c| c.liquidity_usd) {
-            if liq < min_liquidity_usd {
-                return;
-            }
-        }
+    if should_skip_for_liquidity(min_liquidity_usd, ctx.as_ref()) {
+        return;
     }
 
     last_alert.insert(key, Instant::now());
@@ -185,6 +188,20 @@ async fn handle_event(
     );
     if let Err(e) = tg.send(&text).await {
         warn!("telegram send failed: {}", e);
+    }
+}
+
+fn should_skip_for_liquidity(min_liquidity_usd: f64, ctx: Option<&MarketContext>) -> bool {
+    if min_liquidity_usd <= 0.0 {
+        return false;
+    }
+    match ctx.and_then(|c| c.liquidity_usd) {
+        // Gate suppresses only markets whose liquidity is known and below the
+        // threshold. Unknown liquidity (metadata not yet ingested) is allowed
+        // through — we'd rather surface a possibly-thin market than miss a
+        // genuine move on a brand-new listing.
+        Some(liq) => liq < min_liquidity_usd,
+        None => false,
     }
 }
 
@@ -231,7 +248,7 @@ async fn lookup_polymarket(state: &AppState, token_id: &str) -> Option<MarketCon
 
     row.map(|(question, slug, category, liquidity_usd, volume_24h_usd)| MarketContext {
         question,
-        url: (!slug.is_empty()).then(|| format!("https://polymarket.com/event/{}", slug)),
+        slug: (!slug.is_empty()).then_some(slug),
         category: normalize_category(&category),
         liquidity_usd,
         volume_24h_usd,
@@ -260,7 +277,7 @@ async fn lookup_limitless(state: &AppState, market_key: &str) -> Option<MarketCo
 
     row.map(|(question, category, liquidity_usd, volume_24h_usd)| MarketContext {
         question,
-        url: Some(format!("https://limitless.exchange/markets/{}", slug)),
+        slug: Some(slug.to_string()),
         category: category.as_deref().and_then(normalize_category),
         liquidity_usd,
         volume_24h_usd,
@@ -293,97 +310,42 @@ fn format_alert(
     delta_pct: f64,
 ) -> String {
     let arrow = if delta_pct > 0.0 { "↑" } else { "↓" };
-    let question = ctx
+    let emoji = if delta_pct > 0.0 {
+        "\u{1F4C8}"
+    } else {
+        "\u{1F4C9}"
+    };
+    let question_raw = ctx
         .map(|c| c.question.clone())
         .unwrap_or_else(|| format!("{}:{}", venue.as_str(), truncate(market_key, 12)));
 
-    let mut lines = vec![
-        format!("{arrow} {question}"),
-        format!(
-            "{:.1}¢ → {:.1}¢  ({:+.1}%)",
-            prev * 100.0,
-            curr * 100.0,
-            delta_pct
-        ),
-    ];
+    let mut lines: Vec<String> = Vec::new();
+    lines.push(format_alert_header(emoji, "Probability shift", venue.as_str()));
+    lines.push(format!("<i>{}</i>", html_escape(&question_raw)));
+    lines.push(format!(
+        "{arrow} {:.1}¢ → {:.1}¢  ({:+.1}%)",
+        prev * 100.0,
+        curr * 100.0,
+        delta_pct
+    ));
 
     if let Some(c) = ctx {
-        let mut meta: Vec<String> = Vec::new();
-        if let Some(cat) = &c.category {
-            meta.push(cat.clone());
-        }
-        if let Some(liq) = c.liquidity_usd {
-            meta.push(format!("liq {}", format_money(liq)));
-        }
-        if let Some(vol) = c.volume_24h_usd {
-            meta.push(format!("vol {}", format_money(vol)));
-        }
+        let meta = format_metadata_row(
+            c.liquidity_usd,
+            c.volume_24h_usd,
+            c.category.as_deref(),
+        );
         if !meta.is_empty() {
-            lines.push(meta.join(" · "));
+            lines.push(meta);
         }
-        if let Some(url) = &c.url {
-            lines.push(url.clone());
+        if let Some(slug) = &c.slug {
+            if let Some(link) = format_deep_link(venue.as_str(), slug) {
+                lines.push(link);
+            }
         }
     }
 
     lines.join("\n")
-}
-
-fn format_money(v: f64) -> String {
-    let abs = v.abs();
-    if abs >= 1_000_000.0 {
-        format!("${:.1}M", v / 1_000_000.0)
-    } else if abs >= 1_000.0 {
-        format!("${:.1}k", v / 1_000.0)
-    } else {
-        format!("${:.0}", v)
-    }
-}
-
-struct TelegramClient {
-    bot_token: String,
-    chat_id: String,
-    http: reqwest::Client,
-}
-
-impl TelegramClient {
-    fn new(bot_token: String, chat_id: String) -> Self {
-        Self {
-            bot_token,
-            chat_id,
-            http: reqwest::Client::builder()
-                .timeout(Duration::from_secs(5))
-                .build()
-                .expect("reqwest client"),
-        }
-    }
-
-    async fn send(&self, text: &str) -> Result<(), String> {
-        #[derive(Serialize)]
-        struct Payload<'a> {
-            chat_id: &'a str,
-            text: &'a str,
-            disable_web_page_preview: bool,
-        }
-        let url = format!("https://api.telegram.org/bot{}/sendMessage", self.bot_token);
-        let resp = self
-            .http
-            .post(&url)
-            .json(&Payload {
-                chat_id: &self.chat_id,
-                text,
-                disable_web_page_preview: true,
-            })
-            .send()
-            .await
-            .map_err(|e| format!("request: {}", e))?;
-        if !resp.status().is_success() {
-            let code = resp.status();
-            let body = resp.text().await.unwrap_or_default();
-            return Err(format!("telegram {}: {}", code, body));
-        }
-        Ok(())
-    }
 }
 
 #[cfg(test)]
@@ -393,7 +355,7 @@ mod tests {
     fn ctx_full() -> MarketContext {
         MarketContext {
             question: "Will X happen?".to_string(),
-            url: Some("https://polymarket.com/event/will-x".to_string()),
+            slug: Some("will-x".to_string()),
             category: Some("politics".to_string()),
             liquidity_usd: Some(125_000.0),
             volume_24h_usd: Some(3_400_000.0),
@@ -411,6 +373,15 @@ mod tests {
     }
 
     #[test]
+    fn format_header_is_bold_and_venue_titled() {
+        let c = ctx_full();
+        let s = format_alert(Some(&c), Venue::Polymarket, "tok", 0.10, 0.18, 80.0);
+        assert!(s.contains("<b>"));
+        assert!(s.contains("Probability shift"));
+        assert!(s.contains("Polymarket"));
+    }
+
+    #[test]
     fn format_down_arrow_for_negative() {
         let c = ctx_full();
         let s = format_alert(Some(&c), Venue::Polymarket, "tok", 0.50, 0.40, -20.0);
@@ -418,13 +389,42 @@ mod tests {
     }
 
     #[test]
-    fn format_includes_enrichment_when_ctx_present() {
+    fn format_includes_metadata_row_when_ctx_present() {
         let c = ctx_full();
         let s = format_alert(Some(&c), Venue::Polymarket, "tok", 0.10, 0.18, 80.0);
-        assert!(s.contains("politics"));
-        assert!(s.contains("liq $125.0k"));
-        assert!(s.contains("vol $3.4M"));
-        assert!(s.contains("https://polymarket.com/event/will-x"));
+        assert!(s.contains("Liquidity: $125.0k"));
+        assert!(s.contains("24h vol: $3.4M"));
+        assert!(s.contains("Category: politics"));
+        assert!(s.contains("https://polymarket.com/market/will-x"));
+        assert!(s.contains("Open on Polymarket"));
+    }
+
+    #[test]
+    fn format_html_escapes_question() {
+        let c = MarketContext {
+            question: "Will A<B>&C?".to_string(),
+            slug: None,
+            category: None,
+            liquidity_usd: None,
+            volume_24h_usd: None,
+        };
+        let s = format_alert(Some(&c), Venue::Polymarket, "tok", 0.10, 0.15, 50.0);
+        assert!(s.contains("A&lt;B&gt;&amp;C"));
+        assert!(!s.contains("A<B>"));
+    }
+
+    #[test]
+    fn format_limitless_link_uses_limitless_domain() {
+        let c = MarketContext {
+            question: "Q".to_string(),
+            slug: Some("lim-slug".to_string()),
+            category: None,
+            liquidity_usd: None,
+            volume_24h_usd: None,
+        };
+        let s = format_alert(Some(&c), Venue::Limitless, "lim-slug:yes", 0.10, 0.15, 50.0);
+        assert!(s.contains("limitless.exchange/markets/lim-slug"));
+        assert!(s.contains("Open on Limitless"));
     }
 
     #[test]
@@ -438,23 +438,17 @@ mod tests {
     fn format_omits_missing_enrichment_fields() {
         let c = MarketContext {
             question: "Q".to_string(),
-            url: None,
+            slug: None,
             category: None,
             liquidity_usd: None,
             volume_24h_usd: None,
         };
         let s = format_alert(Some(&c), Venue::Polymarket, "tok", 0.10, 0.15, 50.0);
         assert!(s.contains("Q"));
-        assert!(!s.contains("liq "));
-        assert!(!s.contains("vol "));
-        assert!(!s.contains("http"));
-    }
-
-    #[test]
-    fn money_formatter_ranges() {
-        assert_eq!(format_money(42.0), "$42");
-        assert_eq!(format_money(4_200.0), "$4.2k");
-        assert_eq!(format_money(4_200_000.0), "$4.2M");
+        assert!(!s.contains("Liquidity:"));
+        assert!(!s.contains("24h vol:"));
+        assert!(!s.contains("Category:"));
+        assert!(!s.contains("href="));
     }
 
     #[test]
@@ -463,5 +457,60 @@ mod tests {
         assert_eq!(normalize_category("Unknown"), None);
         assert_eq!(normalize_category("  "), None);
         assert_eq!(normalize_category(""), None);
+    }
+
+    #[test]
+    fn liquidity_gate_skips_below_threshold() {
+        let c = MarketContext {
+            question: "Q".to_string(),
+            slug: None,
+            category: None,
+            liquidity_usd: Some(500.0),
+            volume_24h_usd: None,
+        };
+        assert!(should_skip_for_liquidity(1_000.0, Some(&c)));
+    }
+
+    #[test]
+    fn liquidity_gate_passes_above_threshold() {
+        let c = MarketContext {
+            question: "Q".to_string(),
+            slug: None,
+            category: None,
+            liquidity_usd: Some(5_000.0),
+            volume_24h_usd: None,
+        };
+        assert!(!should_skip_for_liquidity(1_000.0, Some(&c)));
+    }
+
+    #[test]
+    fn liquidity_gate_disabled_when_threshold_zero() {
+        let c = MarketContext {
+            question: "Q".to_string(),
+            slug: None,
+            category: None,
+            liquidity_usd: Some(10.0),
+            volume_24h_usd: None,
+        };
+        assert!(!should_skip_for_liquidity(0.0, Some(&c)));
+    }
+
+    #[test]
+    fn liquidity_gate_allows_unknown_liquidity_through() {
+        // Metadata not yet ingested → don't suppress; we'd rather risk a
+        // possibly-thin alert than miss a genuine move on a brand-new listing.
+        let c = MarketContext {
+            question: "Q".to_string(),
+            slug: None,
+            category: None,
+            liquidity_usd: None,
+            volume_24h_usd: None,
+        };
+        assert!(!should_skip_for_liquidity(1_000.0, Some(&c)));
+    }
+
+    #[test]
+    fn liquidity_gate_allows_missing_ctx_through() {
+        assert!(!should_skip_for_liquidity(1_000.0, None));
     }
 }

--- a/app/src/services/probability_alert.rs
+++ b/app/src/services/probability_alert.rs
@@ -395,7 +395,7 @@ mod tests {
         assert!(s.contains("Liquidity: $125.0k"));
         assert!(s.contains("24h vol: $3.4M"));
         assert!(s.contains("Category: politics"));
-        assert!(s.contains("https://polymarket.com/market/will-x"));
+        assert!(s.contains("https://polymarket.com/event/will-x"));
         assert!(s.contains("Open on Polymarket"));
     }
 

--- a/app/src/services/telegram_format.rs
+++ b/app/src/services/telegram_format.rs
@@ -1,0 +1,289 @@
+//! Shared helpers for Telegram alert formatting.
+//!
+//! Every alerter service (probability_alert, cross_venue_arb, new_market_alert,
+//! and future additions such as volume_spike_alert) sends HTML-formatted
+//! messages through a small, consistent layout:
+//!
+//!   <b>{emoji} {signal} — {Venue}</b>
+//!   <i>{question}</i>
+//!   {signal-specific body}
+//!   Liquidity: $X | 24h vol: $Y | Category: Z     (skips missing fields)
+//!   <a href="...">Open on {Venue}</a>
+//!
+//! Formatting helpers live here; every alerter imports them to keep the surface
+//! area uniform. All user-derived strings (question, category, slug) must be
+//! passed through `html_escape` before embedding — Telegram's HTML parser will
+//! reject the whole message if an unescaped `<`, `>` or `&` slips through.
+//!
+//! `TelegramClient` is the shared HTTP client. It posts with
+//! `parse_mode: "HTML"` and `disable_web_page_preview: true`.
+
+use std::time::Duration;
+
+use serde::Serialize;
+
+/// HTML-escapes a user-derived string for safe embedding in a Telegram HTML
+/// message. Covers the characters Telegram's HTML parser requires (`<`, `>`,
+/// `&`) plus the quote characters that would otherwise break attribute values
+/// inside `<a href="...">` tags if the string is ever interpolated into an
+/// attribute.
+pub fn html_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#39;"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+/// Human-readable title for a venue ("Polymarket", "Limitless", ...).
+pub fn venue_title(venue: &str) -> &'static str {
+    match venue {
+        "polymarket" => "Polymarket",
+        "limitless" => "Limitless",
+        "aerodrome" => "Aerodrome",
+        "internal" => "Internal",
+        _ => "Unknown",
+    }
+}
+
+/// Builds the public market URL for a given venue/slug pair.
+///
+/// Returns `None` when the slug is empty or the venue has no public URL
+/// convention. The slug is NOT html-escaped here — embedding the raw URL
+/// into an href attribute is the caller's responsibility (use
+/// `format_deep_link` for the full HTML link).
+pub fn venue_link(venue: &str, slug: &str) -> Option<String> {
+    if slug.is_empty() {
+        return None;
+    }
+    match venue {
+        "polymarket" => Some(format!("https://polymarket.com/market/{}", slug)),
+        "limitless" => Some(format!("https://limitless.exchange/markets/{}", slug)),
+        _ => None,
+    }
+}
+
+/// Returns the HTML anchor line for the alert footer, e.g.
+/// `<a href="https://polymarket.com/market/abc">Open on Polymarket</a>`.
+/// Returns `None` when there's no public URL for this venue/slug.
+pub fn format_deep_link(venue: &str, slug: &str) -> Option<String> {
+    let url = venue_link(venue, slug)?;
+    Some(format!(
+        "<a href=\"{}\">Open on {}</a>",
+        html_escape(&url),
+        venue_title(venue),
+    ))
+}
+
+/// Renders the `<b>{emoji} {signal} — {Venue}</b>` header. `signal` is embedded
+/// as-is and is expected to be a static string supplied by the caller, not a
+/// user-derived value.
+pub fn format_alert_header(emoji: &str, signal: &str, venue: &str) -> String {
+    format!("<b>{} {} — {}</b>", emoji, signal, venue_title(venue))
+}
+
+/// Renders the compact metadata row `Liquidity: $X | 24h vol: $Y | Category: Z`.
+///
+/// Any of the three fields can be absent; missing fields are skipped entirely
+/// so we don't print "Liquidity: -" placeholders. The category string IS
+/// html-escaped inside this helper — callers pass the raw DB value.
+///
+/// Returns an empty string if none of the three fields are present, so callers
+/// can blindly append with a leading newline and trim later.
+pub fn format_metadata_row(
+    liquidity_usd: Option<f64>,
+    volume_24h_usd: Option<f64>,
+    category: Option<&str>,
+) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(l) = liquidity_usd {
+        parts.push(format!("Liquidity: {}", format_money(l)));
+    }
+    if let Some(v) = volume_24h_usd {
+        parts.push(format!("24h vol: {}", format_money(v)));
+    }
+    if let Some(c) = category {
+        let trimmed = c.trim();
+        if !trimmed.is_empty() && !trimmed.eq_ignore_ascii_case("unknown") {
+            parts.push(format!("Category: {}", html_escape(trimmed)));
+        }
+    }
+    parts.join(" | ")
+}
+
+/// Formats a USD value in the compact `$42`, `$4.2k`, `$4.2M` style used by
+/// the alerter output. Shared so every alert row prints the same way.
+pub fn format_money(v: f64) -> String {
+    let abs = v.abs();
+    if abs >= 1_000_000.0 {
+        format!("${:.1}M", v / 1_000_000.0)
+    } else if abs >= 1_000.0 {
+        format!("${:.1}k", v / 1_000.0)
+    } else {
+        format!("${:.0}", v)
+    }
+}
+
+/// Shared Telegram HTTP client. Posts HTML-formatted messages with previews
+/// disabled. Constructed once per alerter from env vars.
+pub struct TelegramClient {
+    bot_token: String,
+    chat_id: String,
+    http: reqwest::Client,
+}
+
+impl TelegramClient {
+    pub fn new(bot_token: String, chat_id: String) -> Self {
+        Self {
+            bot_token,
+            chat_id,
+            http: reqwest::Client::builder()
+                .timeout(Duration::from_secs(5))
+                .build()
+                .expect("reqwest client"),
+        }
+    }
+
+    pub async fn send(&self, text: &str) -> Result<(), String> {
+        #[derive(Serialize)]
+        struct Payload<'a> {
+            chat_id: &'a str,
+            text: &'a str,
+            parse_mode: &'a str,
+            disable_web_page_preview: bool,
+        }
+        let url = format!("https://api.telegram.org/bot{}/sendMessage", self.bot_token);
+        let resp = self
+            .http
+            .post(&url)
+            .json(&Payload {
+                chat_id: &self.chat_id,
+                text,
+                parse_mode: "HTML",
+                disable_web_page_preview: true,
+            })
+            .send()
+            .await
+            .map_err(|e| format!("request: {}", e))?;
+        if !resp.status().is_success() {
+            let code = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(format!("telegram {}: {}", code, body));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn html_escape_covers_risky_chars() {
+        assert_eq!(html_escape("A<B>&C"), "A&lt;B&gt;&amp;C");
+        assert_eq!(html_escape("\"quoted\""), "&quot;quoted&quot;");
+        assert_eq!(html_escape("it's"), "it&#39;s");
+    }
+
+    #[test]
+    fn html_escape_leaves_safe_text_alone() {
+        assert_eq!(html_escape("plain text 123"), "plain text 123");
+        assert_eq!(html_escape(""), "");
+    }
+
+    #[test]
+    fn venue_link_builds_expected_urls() {
+        assert_eq!(
+            venue_link("polymarket", "will-x"),
+            Some("https://polymarket.com/market/will-x".to_string())
+        );
+        assert_eq!(
+            venue_link("limitless", "some-slug"),
+            Some("https://limitless.exchange/markets/some-slug".to_string())
+        );
+    }
+
+    #[test]
+    fn venue_link_returns_none_on_empty_slug_or_unknown_venue() {
+        assert_eq!(venue_link("polymarket", ""), None);
+        assert_eq!(venue_link("unknown-venue", "slug"), None);
+    }
+
+    #[test]
+    fn deep_link_wraps_url_in_anchor() {
+        let s = format_deep_link("polymarket", "abc").unwrap();
+        assert!(s.contains("href=\"https://polymarket.com/market/abc\""));
+        assert!(s.contains("Open on Polymarket"));
+    }
+
+    #[test]
+    fn deep_link_none_when_no_url() {
+        assert_eq!(format_deep_link("polymarket", ""), None);
+        assert_eq!(format_deep_link("aerodrome", "slug"), None);
+    }
+
+    #[test]
+    fn header_uses_em_dash_and_bold() {
+        let h = format_alert_header("\u{1F4C8}", "Probability shift", "polymarket");
+        assert!(h.starts_with("<b>"));
+        assert!(h.contains("Probability shift"));
+        assert!(h.contains("Polymarket"));
+        assert!(h.contains("\u{2014}"));
+    }
+
+    #[test]
+    fn metadata_row_includes_all_fields_when_present() {
+        let s = format_metadata_row(Some(125_000.0), Some(3_400_000.0), Some("politics"));
+        assert_eq!(s, "Liquidity: $125.0k | 24h vol: $3.4M | Category: politics");
+    }
+
+    #[test]
+    fn metadata_row_skips_missing_fields() {
+        let s = format_metadata_row(Some(500.0), None, None);
+        assert_eq!(s, "Liquidity: $500");
+        let s = format_metadata_row(None, Some(2_000.0), None);
+        assert_eq!(s, "24h vol: $2.0k");
+        let s = format_metadata_row(None, None, Some("sports"));
+        assert_eq!(s, "Category: sports");
+    }
+
+    #[test]
+    fn metadata_row_empty_when_all_missing() {
+        let s = format_metadata_row(None, None, None);
+        assert_eq!(s, "");
+    }
+
+    #[test]
+    fn metadata_row_drops_unknown_and_blank_category() {
+        assert_eq!(format_metadata_row(None, None, Some("unknown")), "");
+        assert_eq!(format_metadata_row(None, None, Some("  ")), "");
+        assert_eq!(format_metadata_row(None, None, Some("")), "");
+    }
+
+    #[test]
+    fn metadata_row_html_escapes_category() {
+        let s = format_metadata_row(None, None, Some("a<b>&c"));
+        assert_eq!(s, "Category: a&lt;b&gt;&amp;c");
+    }
+
+    #[test]
+    fn money_formatter_ranges() {
+        assert_eq!(format_money(42.0), "$42");
+        assert_eq!(format_money(4_200.0), "$4.2k");
+        assert_eq!(format_money(4_200_000.0), "$4.2M");
+    }
+
+    #[test]
+    fn venue_title_known_and_unknown() {
+        assert_eq!(venue_title("polymarket"), "Polymarket");
+        assert_eq!(venue_title("limitless"), "Limitless");
+        assert_eq!(venue_title("nope"), "Unknown");
+    }
+}

--- a/app/src/services/telegram_format.rs
+++ b/app/src/services/telegram_format.rs
@@ -64,14 +64,14 @@ pub fn venue_link(venue: &str, slug: &str) -> Option<String> {
         return None;
     }
     match venue {
-        "polymarket" => Some(format!("https://polymarket.com/market/{}", slug)),
+        "polymarket" => Some(format!("https://polymarket.com/event/{}", slug)),
         "limitless" => Some(format!("https://limitless.exchange/markets/{}", slug)),
         _ => None,
     }
 }
 
 /// Returns the HTML anchor line for the alert footer, e.g.
-/// `<a href="https://polymarket.com/market/abc">Open on Polymarket</a>`.
+/// `<a href="https://polymarket.com/event/abc">Open on Polymarket</a>`.
 /// Returns `None` when there's no public URL for this venue/slug.
 pub fn format_deep_link(venue: &str, slug: &str) -> Option<String> {
     let url = venue_link(venue, slug)?;
@@ -202,7 +202,7 @@ mod tests {
     fn venue_link_builds_expected_urls() {
         assert_eq!(
             venue_link("polymarket", "will-x"),
-            Some("https://polymarket.com/market/will-x".to_string())
+            Some("https://polymarket.com/event/will-x".to_string())
         );
         assert_eq!(
             venue_link("limitless", "some-slug"),
@@ -219,7 +219,7 @@ mod tests {
     #[test]
     fn deep_link_wraps_url_in_anchor() {
         let s = format_deep_link("polymarket", "abc").unwrap();
-        assert!(s.contains("href=\"https://polymarket.com/market/abc\""));
+        assert!(s.contains("href=\"https://polymarket.com/event/abc\""));
         assert!(s.contains("Open on Polymarket"));
     }
 


### PR DESCRIPTION
## Summary

Harmonizes Telegram alert formatting across the three live alerters (`probability_alert`, `cross_venue_arb`, `new_market_alert`) and pulls the copy-pasted `TelegramClient` into a single shared module.

- New `app/src/services/telegram_format.rs` owns the client, `html_escape`, `format_alert_header`, `format_metadata_row`, `venue_link`, `format_deep_link`, and `format_money`. All alerters construct `TelegramClient` from env vars and call `.send(text)`.
- All three alert bodies switch to `parse_mode: HTML` and follow the same layout: bold header with emoji + signal + venue, italicized question, signal-specific body, optional `Liquidity: $X | 24h vol: $Y | Category: Z` row, `<a href=...>Open on Venue</a>` footer.
- Every user-derived string (question, category, slug, reason) goes through `html_escape` before being embedded. `html_escape` covers `<`, `>`, `&`, `"`, `'`.
- `probability_alert` liquidity gate is refactored into `should_skip_for_liquidity(threshold, ctx)` so the "skip below threshold" behavior is unit-testable. Unknown liquidity is allowed through so brand-new markets missing metadata are not suppressed.
- `cross_venue_arb` pair lookup now caches per-pair metadata (PM slug, LIM slug, category, liquidity, volume) so the arb alert can render the metadata row and dual venue links alongside the existing PM↔LIM body.
- `new_market_alert` fetches `liquidity_usdc` and `volume_usdc` for both venues so the metadata row is populated from first-tick.

### Not in this PR

- `volume_spike_alert.rs` has not landed on `main` yet; when it does it should adopt `telegram_format` in a follow-up.
- No changes to trigger, cooldown, or threshold logic. Behavior change is strictly in the message body and the (already-existing) liquidity gate plumbing.
- Link pattern follows the task spec (`polymarket.com/market/<slug>` / `limitless.exchange/markets/<slug>`); this differs from the previous `polymarket.com/event/<slug>` in PR 81 / PR 88 and will need a spot-check in staging.

## Test plan

- [ ] `cargo test -p relay44-app --lib services::telegram_format` passes (html escape, metadata row skips missing fields, venue link, deep link).
- [ ] `cargo test -p relay44-app --lib services::probability_alert` passes (format tests + liquidity-gate skip/pass/unknown/disabled).
- [ ] `cargo test -p relay44-app --lib services::cross_venue_arb` passes (header, direction, metadata row, dual links, html escape).
- [ ] `cargo test -p relay44-app --lib services::new_market_alert` passes (watchlist/category match, html escape of question + reason, polymarket vs limitless link).
- [ ] Staging smoke test: flip `TELEGRAM_ALERTS_ENABLED=true` pointed at a test chat, confirm one of each alert type renders correctly (emoji, bold header, italic question, metadata row, clickable footer).
- [ ] Confirm `polymarket.com/market/<slug>` resolves on a live PM slug; if it 404s, follow-up patch to switch back to `/event/`.