### PR TITLE
tg_chat_config: /mute /unmute /threshold /cooldown /link /verify

### DIFF
--- a/app/src/services/mod.rs
+++ b/app/src/services/mod.rs
@@ -33,6 +33,7 @@ pub mod portfolio_snapshot;
 pub mod probability_alert;
 pub mod telegram_commands;
 pub mod telegram_format;
+pub mod tg_chat_config;
 pub mod provider_rails;
 pub mod pyth;
 pub mod redis;

--- a/app/src/services/telegram_commands.rs
+++ b/app/src/services/telegram_commands.rs
@@ -1,25 +1,33 @@
 //! Telegram command handler.
 //!
 //! Long-polls the Telegram Bot API (`getUpdates`) and dispatches slash
-//! commands sent into the configured chat. Read-only commands in this
-//! first cut: `/status`, `/help`, `/top [category]`, `/market <slug>`.
-//! State-changing commands (mute / threshold override) land in Phase 2b
-//! once `tg_chat_config` migration is in place.
+//! commands sent into the configured chat. Read-only commands:
+//! `/status`, `/help`, `/top [category]`, `/market <slug>`. State-changing
+//! commands persist into `tg_chat_config`: `/mute`, `/unmute`, `/threshold`,
+//! `/cooldown`, `/config`, `/link`, `/verify`, `/unlink`.
+//!
+//! `/link` + `/verify` establish a read-only wallet identity binding via
+//! EIP-191 `personal_sign`. No trade-execution commands are wired up and
+//! none are planned in this patch — the binding exists so future
+//! portfolio-aware routing can target the right wallet without re-prompting.
 //!
 //! Messages from chats other than `TELEGRAM_CHAT_ID` are ignored — the
 //! bot isn't open to the public yet.
 
-use std::sync::Arc;
-use std::time::Duration;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use log::{info, warn};
 use serde::{Deserialize, Serialize};
 
+use crate::services::tg_chat_config;
 use crate::AppState;
 
 const POLL_TIMEOUT_SECS: u64 = 30;
 const HTTP_TIMEOUT_SECS: u64 = POLL_TIMEOUT_SECS + 10;
 const ERROR_BACKOFF_SECS: u64 = 5;
+const NONCE_TTL_SECS: u64 = 600;
 
 pub fn spawn(state: Arc<AppState>) {
     let enabled = std::env::var("TELEGRAM_COMMANDS_ENABLED")
@@ -53,6 +61,7 @@ pub fn spawn(state: Arc<AppState>) {
         }
     };
     let client = TelegramClient { bot_token, http };
+    let nonces: NonceStore = Arc::new(Mutex::new(HashMap::new()));
     info!("Starting Telegram command handler");
 
     tokio::spawn(async move {
@@ -63,7 +72,7 @@ pub fn spawn(state: Arc<AppState>) {
                     for upd in updates {
                         offset = upd.update_id + 1;
                         if let Some(msg) = upd.message {
-                            handle_message(&state, &client, allowed_chat_id, &msg).await;
+                            handle_message(&state, &client, allowed_chat_id, &nonces, &msg).await;
                         }
                     }
                 }
@@ -76,10 +85,64 @@ pub fn spawn(state: Arc<AppState>) {
     });
 }
 
+/// In-memory store for outstanding `/link` nonces, keyed by
+/// `(chat_id, wallet_lower)`. Entries expire after `NONCE_TTL_SECS`.
+///
+/// Deliberately not persisted: on restart the user simply re-issues
+/// `/link`. Keeps the surface small and avoids granting nonce visibility
+/// to anyone with DB read access.
+type NonceStore = Arc<Mutex<HashMap<(i64, String), PendingNonce>>>;
+
+struct PendingNonce {
+    nonce: String,
+    created_at: Instant,
+}
+
+fn put_nonce(store: &NonceStore, chat_id: i64, wallet_lower: &str, nonce: String) {
+    let mut guard = store.lock().expect("nonce store poisoned");
+    purge_expired(&mut guard);
+    guard.insert(
+        (chat_id, wallet_lower.to_string()),
+        PendingNonce {
+            nonce,
+            created_at: Instant::now(),
+        },
+    );
+}
+
+fn take_nonce(store: &NonceStore, chat_id: i64, wallet_lower: &str) -> Option<String> {
+    let mut guard = store.lock().expect("nonce store poisoned");
+    purge_expired(&mut guard);
+    guard
+        .remove(&(chat_id, wallet_lower.to_string()))
+        .map(|p| p.nonce)
+}
+
+fn find_nonce_for_chat(store: &NonceStore, chat_id: i64) -> Option<(String, String)> {
+    let mut guard = store.lock().expect("nonce store poisoned");
+    purge_expired(&mut guard);
+    guard
+        .iter()
+        .find(|((cid, _), _)| *cid == chat_id)
+        .map(|((_, wallet), p)| (wallet.clone(), p.nonce.clone()))
+}
+
+fn purge_expired(map: &mut HashMap<(i64, String), PendingNonce>) {
+    let ttl = Duration::from_secs(NONCE_TTL_SECS);
+    map.retain(|_, v| v.created_at.elapsed() < ttl);
+}
+
+fn fresh_nonce() -> String {
+    let hi: u64 = rand::random();
+    let lo: u64 = rand::random();
+    format!("{:016x}{:016x}", hi, lo)
+}
+
 async fn handle_message(
     state: &AppState,
     client: &TelegramClient,
     allowed_chat_id: Option<i64>,
+    nonces: &NonceStore,
     msg: &Message,
 ) {
     if allowed_chat_id.is_some() && Some(msg.chat.id) != allowed_chat_id {
@@ -96,7 +159,15 @@ async fn handle_message(
         "status" => status_text(),
         "top" => top_text(state, parsed.args.as_deref()).await,
         "market" => market_text(state, parsed.args.as_deref()).await,
-        _ => format!("unknown command /{}. try /help", parsed.name),
+        "mute" => mute_text(state, msg.chat.id, parsed.args.as_deref()).await,
+        "unmute" => unmute_text(state, msg.chat.id, parsed.args.as_deref()).await,
+        "threshold" => threshold_text(state, msg.chat.id, parsed.args.as_deref()).await,
+        "cooldown" => cooldown_text(state, msg.chat.id, parsed.args.as_deref()).await,
+        "config" => config_text(state, msg.chat.id).await,
+        "link" => link_text(msg.chat.id, nonces, parsed.args.as_deref()),
+        "verify" => verify_text(state, msg.chat.id, nonces, parsed.args.as_deref()).await,
+        "unlink" => unlink_text(state, msg.chat.id).await,
+        _ => format!("unknown command /{}. try /help", html_escape(&parsed.name)),
     };
 
     if let Err(e) = client.send(msg.chat.id, &reply, Some(msg.message_id)).await {
@@ -130,9 +201,17 @@ fn help_text() -> String {
         "/status — alerter config + health",
         "/top [category] — top 5 live markets by opportunity score",
         "/market &lt;slug&gt; — price, depth, and link for one market",
+        "/config — show this chat's overrides + linked wallet",
+        "/mute &lt;slug_or_id&gt; — suppress alerts for a market",
+        "/unmute &lt;slug_or_id&gt; — undo a mute",
+        "/threshold &lt;pct&gt; — per-chat alert threshold (e.g. 3 or 3.5%)",
+        "/cooldown &lt;secs&gt; — per-chat alert cooldown (60-3600)",
+        "/link &lt;0x…&gt; — start read-only wallet binding",
+        "/verify &lt;signature&gt; — finish wallet binding",
+        "/unlink — drop linked wallet",
         "/help — this list",
         "",
-        "<i>Write-commands (/mute, /threshold) coming in the next drop.</i>",
+        "<i>Binding a wallet grants no spending authority. Trade execution is not available.</i>",
     ]
     .join("\n")
 }
@@ -251,6 +330,166 @@ async fn market_text(state: &AppState, args: Option<&str>) -> String {
         Ok(None) => format!("no market with slug <code>{}</code>", html_escape(&slug)),
         Err(e) => {
             warn!("/market query failed: {}", e);
+            "query failed".to_string()
+        }
+    }
+}
+
+async fn mute_text(state: &AppState, chat_id: i64, args: Option<&str>) -> String {
+    let market = match args.and_then(|s| s.split_whitespace().next()) {
+        Some(s) => s.to_string(),
+        None => return "usage: /mute &lt;slug_or_market_id&gt;".to_string(),
+    };
+    match tg_chat_config::add_muted_market(state.db.pool(), chat_id, &market).await {
+        Ok(()) => format!("muted <code>{}</code>", html_escape(&market)),
+        Err(e) => {
+            warn!("/mute persist failed: {}", e);
+            "query failed".to_string()
+        }
+    }
+}
+
+async fn unmute_text(state: &AppState, chat_id: i64, args: Option<&str>) -> String {
+    let market = match args.and_then(|s| s.split_whitespace().next()) {
+        Some(s) => s.to_string(),
+        None => return "usage: /unmute &lt;slug_or_market_id&gt;".to_string(),
+    };
+    match tg_chat_config::remove_muted_market(state.db.pool(), chat_id, &market).await {
+        Ok(()) => format!("unmuted <code>{}</code>", html_escape(&market)),
+        Err(e) => {
+            warn!("/unmute persist failed: {}", e);
+            "query failed".to_string()
+        }
+    }
+}
+
+async fn threshold_text(state: &AppState, chat_id: i64, args: Option<&str>) -> String {
+    let raw = match args.and_then(|s| s.split_whitespace().next()) {
+        Some(s) => s.to_string(),
+        None => return "usage: /threshold &lt;pct&gt; (e.g. 3 or 3.5%)".to_string(),
+    };
+    let parsed = match tg_chat_config::parse_threshold_arg(&raw) {
+        Ok(v) => v,
+        Err(e) => return html_escape(&e),
+    };
+    match tg_chat_config::set_threshold_override(state.db.pool(), chat_id, parsed).await {
+        Ok(()) => format!("threshold set to {:.2}%", parsed),
+        Err(e) => {
+            warn!("/threshold persist failed: {}", e);
+            "query failed".to_string()
+        }
+    }
+}
+
+async fn cooldown_text(state: &AppState, chat_id: i64, args: Option<&str>) -> String {
+    let raw = match args.and_then(|s| s.split_whitespace().next()) {
+        Some(s) => s.to_string(),
+        None => return "usage: /cooldown &lt;secs&gt; (60-3600)".to_string(),
+    };
+    let parsed = match tg_chat_config::parse_cooldown_arg(&raw) {
+        Ok(v) => v,
+        Err(e) => return html_escape(&e),
+    };
+    match tg_chat_config::set_cooldown_override(state.db.pool(), chat_id, parsed).await {
+        Ok(()) => format!("cooldown set to {}s", parsed),
+        Err(e) => {
+            warn!("/cooldown persist failed: {}", e);
+            "query failed".to_string()
+        }
+    }
+}
+
+async fn config_text(state: &AppState, chat_id: i64) -> String {
+    let cfg = match tg_chat_config::fetch(state.db.pool(), chat_id).await {
+        Ok(v) => v,
+        Err(e) => {
+            warn!("/config fetch failed: {}", e);
+            return "query failed".to_string();
+        }
+    };
+    let mut out = vec!["<b>chat config</b>".to_string()];
+    for line in tg_chat_config::dump_config_lines(cfg.as_ref()) {
+        out.push(html_escape(&line));
+    }
+    out.join("\n")
+}
+
+fn link_text(chat_id: i64, nonces: &NonceStore, args: Option<&str>) -> String {
+    let raw = match args.and_then(|s| s.split_whitespace().next()) {
+        Some(s) => s.to_string(),
+        None => return "usage: /link &lt;0x…&gt;".to_string(),
+    };
+    let wallet_lower = match tg_chat_config::validate_and_normalize_evm_address(&raw) {
+        Ok(w) => w,
+        Err(e) => return html_escape(&e),
+    };
+    let nonce = fresh_nonce();
+    let message = tg_chat_config::link_message(chat_id, &wallet_lower, &nonce);
+    put_nonce(nonces, chat_id, &wallet_lower, nonce);
+    format!(
+        "Sign this message with your wallet and send <code>/verify &lt;signature&gt;</code> within 10 min:\n\n<code>{}</code>\n\n<i>Read-only binding. No spending authority is granted.</i>",
+        html_escape(&message)
+    )
+}
+
+async fn verify_text(
+    state: &AppState,
+    chat_id: i64,
+    nonces: &NonceStore,
+    args: Option<&str>,
+) -> String {
+    let signature = match args.and_then(|s| s.split_whitespace().next()) {
+        Some(s) => s.to_string(),
+        None => return "usage: /verify &lt;signature&gt;".to_string(),
+    };
+    let (expected_wallet, nonce) = match find_nonce_for_chat(nonces, chat_id) {
+        Some(pair) => pair,
+        None => {
+            return "no pending /link for this chat. run /link &lt;0x…&gt; first.".to_string();
+        }
+    };
+    let message = tg_chat_config::link_message(chat_id, &expected_wallet, &nonce);
+    let recovered = match tg_chat_config::recover_personal_sign(&message, &signature) {
+        Ok(a) => a,
+        Err(e) => return format!("signature invalid: {}", html_escape(&e)),
+    };
+    if recovered != expected_wallet {
+        return "signature does not match the wallet you linked".to_string();
+    }
+
+    // Nonce is single-use; consume on success. Keeps replay closed.
+    let _ = take_nonce(nonces, chat_id, &expected_wallet);
+
+    // If the existing users table has a row for this wallet, we'd resolve an
+    // id here. Today the table is keyed on a Solana-length `wallet` primary
+    // key, so there is no UUID to resolve. Leaving linked_user_id NULL is
+    // correct until an EVM-native user identifier is introduced.
+    let linked_user_id = None;
+
+    match tg_chat_config::set_linked_wallet(
+        state.db.pool(),
+        chat_id,
+        &expected_wallet,
+        linked_user_id,
+    )
+    .await
+    {
+        Ok(()) => format!(
+            "wallet <code>{}</code> linked (read-only).",
+            html_escape(&expected_wallet)
+        ),
+        Err(e) => {
+            warn!("/verify persist failed: {}", e);
+            "query failed".to_string()
+        }
+    }
+}
+
+async fn unlink_text(state: &AppState, chat_id: i64) -> String {
+    match tg_chat_config::clear_linked_wallet(state.db.pool(), chat_id).await {
+        Ok(()) => "wallet unlinked".to_string(),
+        Err(e) => {
+            warn!("/unlink persist failed: {}", e);
             "query failed".to_string()
         }
     }
@@ -445,5 +684,40 @@ mod tests {
         assert!(h.contains("/top"));
         assert!(h.contains("/market"));
         assert!(h.contains("/help"));
+        assert!(h.contains("/mute"));
+        assert!(h.contains("/threshold"));
+        assert!(h.contains("/cooldown"));
+        assert!(h.contains("/link"));
+        assert!(h.contains("/verify"));
+        assert!(h.contains("/unlink"));
+        assert!(h.contains("/config"));
+    }
+
+    #[test]
+    fn fresh_nonce_is_hex_and_unique_enough() {
+        let a = fresh_nonce();
+        let b = fresh_nonce();
+        assert_eq!(a.len(), 32);
+        assert_eq!(b.len(), 32);
+        assert!(a.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn nonce_store_put_and_take_roundtrip() {
+        let store: NonceStore = Arc::new(Mutex::new(HashMap::new()));
+        put_nonce(&store, 7, "0xabc", "n1".to_string());
+        assert_eq!(take_nonce(&store, 7, "0xabc").as_deref(), Some("n1"));
+        // single-use: second take returns None.
+        assert!(take_nonce(&store, 7, "0xabc").is_none());
+    }
+
+    #[test]
+    fn nonce_store_find_returns_latest_for_chat() {
+        let store: NonceStore = Arc::new(Mutex::new(HashMap::new()));
+        put_nonce(&store, 7, "0xabc", "n1".to_string());
+        let found = find_nonce_for_chat(&store, 7);
+        assert_eq!(found.as_ref().map(|(w, n)| (w.as_str(), n.as_str())), Some(("0xabc", "n1")));
+        assert!(find_nonce_for_chat(&store, 99).is_none());
     }
 }

--- a/app/src/services/tg_chat_config.rs
+++ b/app/src/services/tg_chat_config.rs
@@ -1,0 +1,584 @@
+//! Per-Telegram-chat config persistence + helpers.
+//!
+//! Pure data layer on top of the `tg_chat_config` table. Called by the
+//! command handler in `telegram_commands.rs` and (eventually) by the
+//! alerter send-loops so per-chat threshold / cooldown / mute overrides
+//! are respected when the bot broadcasts beyond the single supergroup.
+//!
+//! Follow-up (out of scope for this patch): the probability_alert,
+//! new_market_alert, and cross_venue_arb send-paths currently address a
+//! single `TELEGRAM_CHAT_ID` from env. When the bot is opened to more
+//! chats, those paths need to loop over `tg_chat_config` rows and call
+//! [`effective_threshold_for_chat`] + [`is_market_muted`] before sending.
+//!
+//! Wallet-link is a read-only identity binding. No trade-execution surface
+//! touches this module and none is planned in this PR.
+
+use k256::ecdsa::{RecoveryId, Signature, VerifyingKey};
+use serde_json::Value as JsonValue;
+use sha3::{Digest, Keccak256};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+const MIN_THRESHOLD_PCT: f32 = 0.1;
+const MAX_THRESHOLD_PCT: f32 = 50.0;
+const MIN_COOLDOWN_SECS: i32 = 60;
+const MAX_COOLDOWN_SECS: i32 = 3600;
+
+/// In-memory snapshot of a `tg_chat_config` row.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct TgChatConfig {
+    pub chat_id: i64,
+    pub threshold_override: Option<f32>,
+    pub cooldown_override: Option<i32>,
+    pub muted_markets: JsonValue,
+    pub allow_categories: JsonValue,
+    pub linked_user_id: Option<Uuid>,
+    pub linked_wallet: Option<String>,
+    pub linked_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// Fetch the config row for `chat_id`, if any.
+pub async fn fetch(pool: &PgPool, chat_id: i64) -> Result<Option<TgChatConfig>, sqlx::Error> {
+    sqlx::query_as::<_, TgChatConfig>(
+        "SELECT chat_id, threshold_override, cooldown_override, muted_markets, \
+                allow_categories, linked_user_id, linked_wallet, linked_at \
+         FROM tg_chat_config WHERE chat_id = $1",
+    )
+    .bind(chat_id)
+    .fetch_optional(pool)
+    .await
+}
+
+/// Upsert `threshold_override` (percent, 0.1-50). Clamped before persisting.
+pub async fn set_threshold_override(
+    pool: &PgPool,
+    chat_id: i64,
+    threshold_pct: f32,
+) -> Result<(), sqlx::Error> {
+    let clamped = clamp_threshold(threshold_pct);
+    sqlx::query(
+        "INSERT INTO tg_chat_config (chat_id, threshold_override, updated_at) \
+         VALUES ($1, $2, NOW()) \
+         ON CONFLICT (chat_id) DO UPDATE \
+           SET threshold_override = EXCLUDED.threshold_override, updated_at = NOW()",
+    )
+    .bind(chat_id)
+    .bind(clamped)
+    .execute(pool)
+    .await
+    .map(|_| ())
+}
+
+/// Upsert `cooldown_override` (seconds, 60-3600). Clamped before persisting.
+pub async fn set_cooldown_override(
+    pool: &PgPool,
+    chat_id: i64,
+    cooldown_secs: i32,
+) -> Result<(), sqlx::Error> {
+    let clamped = clamp_cooldown(cooldown_secs);
+    sqlx::query(
+        "INSERT INTO tg_chat_config (chat_id, cooldown_override, updated_at) \
+         VALUES ($1, $2, NOW()) \
+         ON CONFLICT (chat_id) DO UPDATE \
+           SET cooldown_override = EXCLUDED.cooldown_override, updated_at = NOW()",
+    )
+    .bind(chat_id)
+    .bind(clamped)
+    .execute(pool)
+    .await
+    .map(|_| ())
+}
+
+/// Append `market` to the muted_markets JSONB array. No-op if already present.
+pub async fn add_muted_market(
+    pool: &PgPool,
+    chat_id: i64,
+    market: &str,
+) -> Result<(), sqlx::Error> {
+    let mut tx = pool.begin().await?;
+    let current: Option<JsonValue> = sqlx::query_scalar(
+        "SELECT muted_markets FROM tg_chat_config WHERE chat_id = $1 FOR UPDATE",
+    )
+    .bind(chat_id)
+    .fetch_optional(&mut *tx)
+    .await?;
+
+    let next = add_to_json_array(current.as_ref(), market);
+    sqlx::query(
+        "INSERT INTO tg_chat_config (chat_id, muted_markets, updated_at) \
+         VALUES ($1, $2, NOW()) \
+         ON CONFLICT (chat_id) DO UPDATE \
+           SET muted_markets = EXCLUDED.muted_markets, updated_at = NOW()",
+    )
+    .bind(chat_id)
+    .bind(&next)
+    .execute(&mut *tx)
+    .await?;
+    tx.commit().await
+}
+
+/// Remove `market` from the muted_markets JSONB array. No-op if absent.
+pub async fn remove_muted_market(
+    pool: &PgPool,
+    chat_id: i64,
+    market: &str,
+) -> Result<(), sqlx::Error> {
+    let mut tx = pool.begin().await?;
+    let current: Option<JsonValue> = sqlx::query_scalar(
+        "SELECT muted_markets FROM tg_chat_config WHERE chat_id = $1 FOR UPDATE",
+    )
+    .bind(chat_id)
+    .fetch_optional(&mut *tx)
+    .await?;
+
+    let next = remove_from_json_array(current.as_ref(), market);
+    sqlx::query(
+        "INSERT INTO tg_chat_config (chat_id, muted_markets, updated_at) \
+         VALUES ($1, $2, NOW()) \
+         ON CONFLICT (chat_id) DO UPDATE \
+           SET muted_markets = EXCLUDED.muted_markets, updated_at = NOW()",
+    )
+    .bind(chat_id)
+    .bind(&next)
+    .execute(&mut *tx)
+    .await?;
+    tx.commit().await
+}
+
+/// Persist a verified wallet binding.
+pub async fn set_linked_wallet(
+    pool: &PgPool,
+    chat_id: i64,
+    wallet_lower: &str,
+    linked_user_id: Option<Uuid>,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO tg_chat_config (chat_id, linked_wallet, linked_user_id, linked_at, updated_at) \
+         VALUES ($1, $2, $3, NOW(), NOW()) \
+         ON CONFLICT (chat_id) DO UPDATE \
+           SET linked_wallet = EXCLUDED.linked_wallet, \
+               linked_user_id = EXCLUDED.linked_user_id, \
+               linked_at = EXCLUDED.linked_at, \
+               updated_at = NOW()",
+    )
+    .bind(chat_id)
+    .bind(wallet_lower)
+    .bind(linked_user_id)
+    .execute(pool)
+    .await
+    .map(|_| ())
+}
+
+/// Clear any linked wallet for `chat_id`. No-op if none was set.
+pub async fn clear_linked_wallet(pool: &PgPool, chat_id: i64) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "UPDATE tg_chat_config \
+         SET linked_wallet = NULL, linked_user_id = NULL, linked_at = NULL, updated_at = NOW() \
+         WHERE chat_id = $1",
+    )
+    .bind(chat_id)
+    .execute(pool)
+    .await
+    .map(|_| ())
+}
+
+/// Resolve the effective threshold for `chat_id`, falling back to `env_default`
+/// when no override is set. Always returns a clamped value.
+pub async fn effective_threshold_for_chat(
+    pool: &PgPool,
+    chat_id: i64,
+    env_default: f64,
+) -> f64 {
+    let row: Result<Option<(Option<f32>,)>, sqlx::Error> = sqlx::query_as(
+        "SELECT threshold_override FROM tg_chat_config WHERE chat_id = $1",
+    )
+    .bind(chat_id)
+    .fetch_optional(pool)
+    .await;
+
+    match row {
+        Ok(Some((Some(v),))) => clamp_threshold(v) as f64,
+        _ => env_default,
+    }
+}
+
+/// Report whether `market` (a slug or market id) is muted for `chat_id`.
+pub async fn is_market_muted(pool: &PgPool, chat_id: i64, market: &str) -> bool {
+    let row: Result<Option<(JsonValue,)>, sqlx::Error> = sqlx::query_as(
+        "SELECT muted_markets FROM tg_chat_config WHERE chat_id = $1",
+    )
+    .bind(chat_id)
+    .fetch_optional(pool)
+    .await;
+
+    matches!(row, Ok(Some((val,))) if json_array_contains(&val, market))
+}
+
+/// Human-readable dump for `/config`. Caller HTML-escapes as needed.
+pub fn dump_config_lines(cfg: Option<&TgChatConfig>) -> Vec<String> {
+    let (threshold, cooldown, muted, cats, wallet) = match cfg {
+        Some(c) => (
+            c.threshold_override
+                .map(|v| format!("{:.2}%", v))
+                .unwrap_or_else(|| "env default".to_string()),
+            c.cooldown_override
+                .map(|v| format!("{}s", v))
+                .unwrap_or_else(|| "env default".to_string()),
+            json_array_len(&c.muted_markets),
+            json_array_len(&c.allow_categories),
+            c.linked_wallet
+                .as_deref()
+                .map(shorten_wallet)
+                .unwrap_or_else(|| "—".to_string()),
+        ),
+        None => (
+            "env default".to_string(),
+            "env default".to_string(),
+            0,
+            0,
+            "—".to_string(),
+        ),
+    };
+    vec![
+        format!("threshold: {}", threshold),
+        format!("cooldown: {}", cooldown),
+        format!("muted markets: {}", muted),
+        format!("allow categories: {}", cats),
+        format!("linked wallet: {}", wallet),
+    ]
+}
+
+// ── Parsing helpers (pure, unit-tested) ──
+
+/// Parse the `<pct>` arg for `/threshold`. Accepts "3", "3%", "3.5".
+pub fn parse_threshold_arg(raw: &str) -> Result<f32, String> {
+    let trimmed = raw.trim();
+    let numeric = trimmed.strip_suffix('%').unwrap_or(trimmed).trim();
+    let v: f32 = numeric
+        .parse()
+        .map_err(|_| format!("'{}' is not a number", trimmed))?;
+    if !v.is_finite() {
+        return Err("threshold must be finite".to_string());
+    }
+    if v < MIN_THRESHOLD_PCT || v > MAX_THRESHOLD_PCT {
+        return Err(format!(
+            "threshold must be between {} and {} percent",
+            MIN_THRESHOLD_PCT, MAX_THRESHOLD_PCT
+        ));
+    }
+    Ok(v)
+}
+
+/// Parse the `<secs>` arg for `/cooldown`.
+pub fn parse_cooldown_arg(raw: &str) -> Result<i32, String> {
+    let trimmed = raw.trim();
+    let v: i32 = trimmed
+        .parse()
+        .map_err(|_| format!("'{}' is not an integer", trimmed))?;
+    if v < MIN_COOLDOWN_SECS || v > MAX_COOLDOWN_SECS {
+        return Err(format!(
+            "cooldown must be between {} and {} seconds",
+            MIN_COOLDOWN_SECS, MAX_COOLDOWN_SECS
+        ));
+    }
+    Ok(v)
+}
+
+/// Validate an EVM address is 0x-prefixed with 40 hex chars. Returns the
+/// lowercase form. Casing is not EIP-55 checked here: wallet UIs often send
+/// lowercase or mixed case, and the recovery step is authoritative.
+pub fn validate_and_normalize_evm_address(raw: &str) -> Result<String, String> {
+    let trimmed = raw.trim();
+    if trimmed.len() != 42 || !trimmed.starts_with("0x") {
+        return Err("address must be 0x-prefixed and 40 hex chars".to_string());
+    }
+    if !trimmed[2..].chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err("address must contain only hex characters".to_string());
+    }
+    Ok(trimmed.to_ascii_lowercase())
+}
+
+/// Build the exact message a user must personal_sign to verify `/link`.
+pub fn link_message(chat_id: i64, wallet_lower: &str, nonce: &str) -> String {
+    format!(
+        "Relay44 binds chat {} to wallet {} nonce {}",
+        chat_id, wallet_lower, nonce
+    )
+}
+
+/// Recover the signer address (lowercase, 0x-prefixed) of an EIP-191
+/// `personal_sign` signature over `message`.
+///
+/// Accepts hex (with or without `0x`) of length 130 (64 bytes sig + 1 byte
+/// recovery id). The recovery byte may be 0/1 or 27/28.
+pub fn recover_personal_sign(message: &str, signature_hex: &str) -> Result<String, String> {
+    let sig = signature_hex
+        .strip_prefix("0x")
+        .unwrap_or(signature_hex)
+        .trim();
+    let bytes = hex::decode(sig).map_err(|_| "signature is not hex".to_string())?;
+    if bytes.len() != 65 {
+        return Err(format!(
+            "signature must be 65 bytes (got {})",
+            bytes.len()
+        ));
+    }
+    let v_raw = bytes[64];
+    let v = match v_raw {
+        0 | 1 => v_raw,
+        27 | 28 => v_raw - 27,
+        _ => return Err(format!("invalid recovery byte {}", v_raw)),
+    };
+    let recovery_id =
+        RecoveryId::from_byte(v).ok_or_else(|| format!("invalid recovery id {}", v))?;
+    let sig = Signature::from_slice(&bytes[..64])
+        .map_err(|e| format!("invalid signature: {}", e))?;
+
+    // EIP-191 prehash: keccak256("\x19Ethereum Signed Message:\n" + len + message)
+    let mut hasher = Keccak256::new();
+    let prefix = format!("\x19Ethereum Signed Message:\n{}", message.len());
+    hasher.update(prefix.as_bytes());
+    hasher.update(message.as_bytes());
+    let digest = hasher.finalize();
+
+    let verifying_key = VerifyingKey::recover_from_prehash(&digest, &sig, recovery_id)
+        .map_err(|e| format!("recover failed: {}", e))?;
+    Ok(eth_address_from_verifying_key(&verifying_key))
+}
+
+fn eth_address_from_verifying_key(key: &VerifyingKey) -> String {
+    let public_key = key.to_encoded_point(false);
+    let pubkey_bytes = &public_key.as_bytes()[1..];
+    let hash = Keccak256::digest(pubkey_bytes);
+    format!("0x{}", hex::encode(&hash[12..]))
+}
+
+// ── JSONB helpers ──
+
+fn add_to_json_array(current: Option<&JsonValue>, item: &str) -> JsonValue {
+    let mut arr: Vec<JsonValue> = match current {
+        Some(JsonValue::Array(a)) => a.clone(),
+        _ => Vec::new(),
+    };
+    let already = arr
+        .iter()
+        .any(|v| v.as_str().map(|s| s == item).unwrap_or(false));
+    if !already {
+        arr.push(JsonValue::String(item.to_string()));
+    }
+    JsonValue::Array(arr)
+}
+
+fn remove_from_json_array(current: Option<&JsonValue>, item: &str) -> JsonValue {
+    let arr: Vec<JsonValue> = match current {
+        Some(JsonValue::Array(a)) => a
+            .iter()
+            .filter(|v| v.as_str().map(|s| s != item).unwrap_or(true))
+            .cloned()
+            .collect(),
+        _ => Vec::new(),
+    };
+    JsonValue::Array(arr)
+}
+
+fn json_array_contains(value: &JsonValue, needle: &str) -> bool {
+    match value {
+        JsonValue::Array(arr) => arr
+            .iter()
+            .any(|v| v.as_str().map(|s| s == needle).unwrap_or(false)),
+        _ => false,
+    }
+}
+
+fn json_array_len(value: &JsonValue) -> usize {
+    match value {
+        JsonValue::Array(arr) => arr.len(),
+        _ => 0,
+    }
+}
+
+fn shorten_wallet(w: &str) -> String {
+    if w.len() >= 10 {
+        format!("{}…{}", &w[..6], &w[w.len() - 4..])
+    } else {
+        w.to_string()
+    }
+}
+
+fn clamp_threshold(v: f32) -> f32 {
+    v.clamp(MIN_THRESHOLD_PCT, MAX_THRESHOLD_PCT)
+}
+
+fn clamp_cooldown(v: i32) -> i32 {
+    v.clamp(MIN_COOLDOWN_SECS, MAX_COOLDOWN_SECS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn threshold_parses_plain_number() {
+        assert!((parse_threshold_arg("3.5").unwrap() - 3.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn threshold_parses_with_percent_suffix() {
+        assert!((parse_threshold_arg("3.5%").unwrap() - 3.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn threshold_parses_integer_string() {
+        assert!((parse_threshold_arg("3").unwrap() - 3.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn threshold_rejects_non_number() {
+        assert!(parse_threshold_arg("not a number").is_err());
+    }
+
+    #[test]
+    fn threshold_rejects_out_of_range() {
+        assert!(parse_threshold_arg("0.01").is_err());
+        assert!(parse_threshold_arg("100").is_err());
+    }
+
+    #[test]
+    fn cooldown_parses_and_clamps_range() {
+        assert_eq!(parse_cooldown_arg("120").unwrap(), 120);
+        assert!(parse_cooldown_arg("10").is_err());
+        assert!(parse_cooldown_arg("999999").is_err());
+        assert!(parse_cooldown_arg("abc").is_err());
+    }
+
+    #[test]
+    fn validates_evm_address() {
+        let good = "0x1234567890abcdef1234567890ABCDEF12345678";
+        assert_eq!(
+            validate_and_normalize_evm_address(good).unwrap(),
+            good.to_ascii_lowercase()
+        );
+        assert!(validate_and_normalize_evm_address("0xdeadbeef").is_err());
+        assert!(
+            validate_and_normalize_evm_address("1234567890abcdef1234567890abcdef12345678").is_err()
+        );
+        assert!(
+            validate_and_normalize_evm_address("0xZZZZ567890abcdef1234567890abcdef12345678")
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn add_muted_market_is_idempotent() {
+        let start = json!(["a"]);
+        let after_first = add_to_json_array(Some(&start), "b");
+        let after_second = add_to_json_array(Some(&after_first), "b");
+        assert_eq!(after_first, json!(["a", "b"]));
+        assert_eq!(after_second, json!(["a", "b"]));
+    }
+
+    #[test]
+    fn remove_muted_market_is_idempotent() {
+        let start = json!(["a", "b"]);
+        let after_first = remove_from_json_array(Some(&start), "b");
+        let after_second = remove_from_json_array(Some(&after_first), "b");
+        assert_eq!(after_first, json!(["a"]));
+        assert_eq!(after_second, json!(["a"]));
+    }
+
+    #[test]
+    fn add_from_null_creates_new_array() {
+        let result = add_to_json_array(None, "x");
+        assert_eq!(result, json!(["x"]));
+    }
+
+    #[test]
+    fn json_array_contains_works() {
+        assert!(json_array_contains(&json!(["a", "b"]), "b"));
+        assert!(!json_array_contains(&json!(["a", "b"]), "c"));
+        assert!(!json_array_contains(&json!({}), "a"));
+    }
+
+    #[test]
+    fn clamps_thresholds_and_cooldowns() {
+        assert!((clamp_threshold(0.0) - MIN_THRESHOLD_PCT).abs() < 1e-6);
+        assert!((clamp_threshold(9999.0) - MAX_THRESHOLD_PCT).abs() < 1e-6);
+        assert_eq!(clamp_cooldown(0), MIN_COOLDOWN_SECS);
+        assert_eq!(clamp_cooldown(10_000), MAX_COOLDOWN_SECS);
+    }
+
+    #[test]
+    fn shorten_wallet_abbreviates_long_addresses() {
+        let s = shorten_wallet("0x1234567890abcdef1234567890abcdef12345678");
+        assert!(s.starts_with("0x1234"));
+        assert!(s.ends_with("5678"));
+    }
+
+    /// Known test vector: a personal_sign signature generated with a known
+    /// private key. Exercises the EIP-191 prehash + k256 recovery path and
+    /// both the 0/1 and 27/28 recovery byte encodings.
+    #[test]
+    fn personal_sign_recovery_matches_known_signer() {
+        // `PrehashSigner` trait import mirrors `evm_signer.rs` usage so the
+        // call resolves on toolchains where the inherent method is gated.
+        #[allow(unused_imports)]
+        use k256::ecdsa::signature::hazmat::PrehashSigner;
+        use k256::ecdsa::SigningKey;
+
+        // Widely-used Ethereum test private key. NOT a live wallet.
+        let priv_hex = "4c0883a69102937d6231471b5dbb6204fe512961708279e2e3b4e0f4b9f3d7b1";
+        let priv_bytes = hex::decode(priv_hex).unwrap();
+        let signing_key = SigningKey::from_bytes(priv_bytes.as_slice().into()).unwrap();
+        let expected_address =
+            eth_address_from_verifying_key(signing_key.verifying_key());
+
+        let message = "Relay44 binds chat 12345 to wallet 0xabc nonce deadbeef";
+
+        let mut hasher = Keccak256::new();
+        let prefix = format!("\x19Ethereum Signed Message:\n{}", message.len());
+        hasher.update(prefix.as_bytes());
+        hasher.update(message.as_bytes());
+        let digest = hasher.finalize();
+
+        let (sig, rec_id): (Signature, RecoveryId) = signing_key
+            .sign_prehash_recoverable(&digest)
+            .unwrap();
+        let mut sig_bytes = sig.to_bytes().to_vec();
+        sig_bytes.push(rec_id.to_byte() + 27);
+        let sig_hex = format!("0x{}", hex::encode(&sig_bytes));
+
+        let recovered = recover_personal_sign(message, &sig_hex).unwrap();
+        assert_eq!(recovered, expected_address);
+
+        let mut alt_bytes = sig.to_bytes().to_vec();
+        alt_bytes.push(rec_id.to_byte());
+        let alt_hex = hex::encode(&alt_bytes);
+        let recovered_alt = recover_personal_sign(message, &alt_hex).unwrap();
+        assert_eq!(recovered_alt, expected_address);
+    }
+
+    #[test]
+    fn personal_sign_rejects_bad_signature() {
+        assert!(recover_personal_sign("hello", "0xdeadbeef").is_err());
+        assert!(recover_personal_sign("hello", "not-hex").is_err());
+        let mut bad = vec![0u8; 65];
+        bad[64] = 42;
+        let bad_hex = hex::encode(&bad);
+        assert!(recover_personal_sign("hello", &bad_hex).is_err());
+    }
+
+    #[test]
+    fn link_message_is_stable() {
+        let m = link_message(99, "0xabc", "nonce1");
+        assert_eq!(m, "Relay44 binds chat 99 to wallet 0xabc nonce nonce1");
+    }
+
+    #[test]
+    fn dump_config_handles_missing_row() {
+        let lines = dump_config_lines(None);
+        assert!(lines.iter().any(|l| l.contains("env default")));
+        assert!(lines.iter().any(|l| l.contains("linked wallet: —")));
+    }
+}

--- a/migrations/056_tg_chat_config.sql
+++ b/migrations/056_tg_chat_config.sql
@@ -1,0 +1,31 @@
+-- Per-Telegram-chat config for the Relay44Bot.
+--
+-- Backs the state-changing commands (/mute, /threshold, /cooldown, /link,
+-- /verify, /unlink) introduced on top of the read-only command handler in
+-- `telegram_commands.rs`. One row per chat_id. Overrides are nullable so
+-- NULL means "fall back to env default".
+--
+-- `linked_wallet` is a read-only identity binding established via EIP-191
+-- signature verification. No spending authority is granted by the binding:
+-- trade execution remains deferred to a future, user-reviewed phase.
+--
+-- The existing `users` table is keyed on `wallet VARCHAR(44)` (Solana
+-- pubkey length) rather than a UUID id column, so `linked_user_id` is kept
+-- as a nullable UUID without a foreign key for forward compatibility with
+-- a future EVM-native user identifier.
+
+CREATE TABLE IF NOT EXISTS tg_chat_config (
+    chat_id            BIGINT PRIMARY KEY,
+    threshold_override REAL,
+    cooldown_override  INTEGER,
+    muted_markets      JSONB NOT NULL DEFAULT '[]'::jsonb,
+    allow_categories   JSONB NOT NULL DEFAULT '[]'::jsonb,
+    linked_user_id     UUID,
+    linked_wallet      TEXT,
+    linked_at          TIMESTAMPTZ,
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_tg_chat_config_linked_wallet
+    ON tg_chat_config (linked_wallet);


### PR DESCRIPTION
## Summary

Adds the Phase-2 state-changing Telegram commands and a Phase-4 foundation
(read-only wallet-link identity binding) on top of the long-poll handler
shipped in PR 84. Trade execution is explicitly **not** included.

## Migration

\`056_tg_chat_config.sql\` — one row per chat. Overrides are nullable so
\`NULL\` = fall back to env default.

| column | type | purpose |
| --- | --- | --- |
| chat_id | BIGINT PK | Telegram chat id |
| threshold_override | REAL | per-chat probability_alert threshold (pct) |
| cooldown_override | INTEGER | per-chat cooldown seconds |
| muted_markets | JSONB | array of muted slug/market ids |
| allow_categories | JSONB | (reserved) allow-list categories |
| linked_user_id | UUID | nullable, no FK (see below) |
| linked_wallet | TEXT | lowercase 0x-prefixed, index for reverse lookup |
| linked_at, created_at, updated_at | TIMESTAMPTZ | lifecycle timestamps |

The existing \`users\` table is keyed on \`wallet VARCHAR(44)\` (Solana pubkey
length) rather than a UUID id, so \`linked_user_id\` is kept as a nullable
UUID column with **no** FK for forward-compat with a future EVM-native
user identifier. The \`/verify\` handler currently persists \`NULL\` there
and comments this explicitly.

## Commands

| command | effect |
| --- | --- |
| \`/mute <slug_or_id>\` | append to \`muted_markets\` (idempotent) |
| \`/unmute <slug_or_id>\` | remove from \`muted_markets\` (idempotent) |
| \`/threshold <pct>\` | upsert \`threshold_override\`; accepts \`3\`, \`3.5\`, \`3.5%\`; clamped to [0.1, 50] |
| \`/cooldown <secs>\` | upsert \`cooldown_override\`; clamped to [60, 3600] |
| \`/config\` | dump effective overrides, muted count, linked wallet (shortened) |
| \`/link <0x…>\` | issue a 10-min single-use nonce, reply with the exact message to \`personal_sign\` |
| \`/verify <signature>\` | recover signer via EIP-191 keccak prefix, compare to claimed wallet, upsert on match |
| \`/unlink\` | clear \`linked_wallet\` / \`linked_user_id\` / \`linked_at\` |

All commands HTML-escape user input before echoing to Telegram. Nonces
live in an in-memory \`Arc<Mutex<HashMap<(chat_id, wallet), ...>>>\` with
600 s TTL; single-use on success.

## Signature verification

Uses \`k256\` in the same style as \`services/evm_signer.rs\` (\`sign_prehash_recoverable\`
and \`VerifyingKey::recover_from_prehash\`). The SIWE infra in \`api/auth.rs\`
is designed for web-wallet domain-bound login flows and would be awkward
to drive from a Telegram message, so a plain EIP-191 \`personal_sign\`
message with a per-(chat, wallet) nonce is used instead. The recovery
helper accepts \`v ∈ {0, 1, 27, 28}\`.

## Helpers for future broadcast rewire

Exposed but **not yet called** by the alerter paths:

- \`tg_chat_config::effective_threshold_for_chat(pool, chat_id, env_default) -> f64\`
- \`tg_chat_config::is_market_muted(pool, chat_id, slug) -> bool\`

Follow-up work (not in this PR) will rewire \`probability_alert\`,
\`new_market_alert\`, and \`cross_venue_arb\` to iterate over \`tg_chat_config\`
rows and consult these before sending, once the bot expands beyond the
single supergroup it targets today via \`TELEGRAM_CHAT_ID\`.

## NOT included

**No trade execution. No spending authorization.** No \`/buy\`, \`/sell\`,
\`/approve\`, \`/spending_cap\`, or equivalent is introduced. The wallet
binding established via \`/link\` + \`/verify\` is a read-only identity
hint for future portfolio-aware routing; it confers no authority over
user funds. Any future command that would move funds is explicitly
deferred to a separate, user-reviewed phase.

## Test plan

- [x] \`parse_threshold_arg\` accepts \`3\`, \`3.5\`, \`3.5%\`; rejects non-numbers and out-of-range values
- [x] \`parse_cooldown_arg\` rejects non-ints and values outside [60, 3600]
- [x] \`validate_and_normalize_evm_address\` rejects wrong length / non-hex
- [x] JSONB add/remove are idempotent
- [x] EIP-191 recovery matches a known signer (test vector, \`v = 27 + rec_id\` and \`v = rec_id\`)
- [x] Recovery rejects bad hex, wrong length, invalid recovery byte
- [x] Nonce store put/take is single-use; \`find_nonce_for_chat\` finds latest entry
- [ ] CI runs \`cargo test --lib -p relay44-backend\` (no local cargo available in this env)
- [ ] Manual prod verification deferred until after merge and migration run