### PR TITLE
alerts: route telegram deep links to relay44.com/markets

### DIFF
--- a/app/src/services/cross_venue_arb.rs
+++ b/app/src/services/cross_venue_arb.rs
@@ -22,7 +22,7 @@ use tokio::sync::RwLock;
 
 use super::market_data::{L2Event, L2Payload, Venue};
 use super::telegram_format::{
-    format_deep_link, format_metadata_row, html_escape, TelegramClient,
+    format_metadata_row, html_escape, venue_link, TelegramClient,
 };
 use crate::AppState;
 
@@ -376,17 +376,23 @@ fn format_alert(meta: &PairMeta, outcome: Outcome, pm: f64, lim: f64) -> String 
         lines.push(meta_row);
     }
 
-    // Dual footer: one link per venue so readers can jump to whichever side
-    // they're more comfortable trading on.
+    // Dual footer: both sides are indexed on Relay44 under their own slugs so
+    // the reader can jump to the PM or LIM side of the arb on our platform.
     let mut link_parts: Vec<String> = Vec::new();
     if let Some(slug) = &meta.pm_slug {
-        if let Some(link) = format_deep_link("polymarket", slug) {
-            link_parts.push(link);
+        if let Some(url) = venue_link("polymarket", slug) {
+            link_parts.push(format!(
+                "<a href=\"{}\">Trade PM side on Relay44</a>",
+                html_escape(&url)
+            ));
         }
     }
     if let Some(slug) = &meta.lim_slug {
-        if let Some(link) = format_deep_link("limitless", slug) {
-            link_parts.push(link);
+        if let Some(url) = venue_link("limitless", slug) {
+            link_parts.push(format!(
+                "<a href=\"{}\">Trade LIM side on Relay44</a>",
+                html_escape(&url)
+            ));
         }
     }
     if !link_parts.is_empty() {
@@ -465,10 +471,10 @@ mod tests {
         assert!(s.contains("Liquidity: $50.0k"));
         assert!(s.contains("24h vol: $1.2M"));
         assert!(s.contains("Category: politics"));
-        assert!(s.contains("polymarket.com/event/pm-slug"));
-        assert!(s.contains("limitless.exchange/markets/lim-slug"));
-        assert!(s.contains("Open on Polymarket"));
-        assert!(s.contains("Open on Limitless"));
+        assert!(s.contains("relay44.com/markets/pm-slug"));
+        assert!(s.contains("relay44.com/markets/lim-slug"));
+        assert!(s.contains("Trade PM side on Relay44"));
+        assert!(s.contains("Trade LIM side on Relay44"));
     }
 
     #[test]

--- a/app/src/services/new_market_alert.rs
+++ b/app/src/services/new_market_alert.rs
@@ -365,8 +365,8 @@ mod tests {
         assert!(s.contains("New market"));
         assert!(s.contains("Polymarket"));
         assert!(s.contains("<i>Will BTC hit 100k?</i>"));
-        assert!(s.contains("polymarket.com/event/example-slug"));
-        assert!(s.contains("Open on Polymarket"));
+        assert!(s.contains("relay44.com/markets/example-slug"));
+        assert!(s.contains("Trade on Relay44"));
         assert!(s.contains("kw:btc"));
     }
 
@@ -394,17 +394,17 @@ mod tests {
         let mut m = sample("Will BTC hit 100k?", "crypto");
         m.slug.clear();
         let s = format_alert(&m, "kw:btc");
-        assert!(!s.contains("polymarket.com"));
+        assert!(!s.contains("relay44.com"));
     }
 
     #[test]
-    fn alert_limitless_uses_limitless_link() {
+    fn alert_limitless_uses_relay44_link() {
         let mut m = sample("Will BTC hit 100k?", "crypto");
         m.venue = "limitless";
         m.slug = "lim-slug".to_string();
         let s = format_alert(&m, "kw:btc");
-        assert!(s.contains("limitless.exchange/markets/lim-slug"));
-        assert!(s.contains("Open on Limitless"));
+        assert!(s.contains("relay44.com/markets/lim-slug"));
+        assert!(s.contains("Trade on Relay44"));
         assert!(s.contains("Limitless"));
     }
 

--- a/app/src/services/orderbook_imbalance_alert.rs
+++ b/app/src/services/orderbook_imbalance_alert.rs
@@ -391,12 +391,12 @@ fn format_alert(
         Venue::Polymarket => (
             "Polymarket",
             ctx.and_then(|c| c.slug.as_deref())
-                .map(|s| format!("https://polymarket.com/market/{}", s)),
+                .map(|s| format!("https://relay44.com/markets/{}", s)),
         ),
         Venue::Limitless => (
             "Limitless",
             ctx.and_then(|c| c.slug.as_deref())
-                .map(|s| format!("https://limitless.exchange/markets/{}", s)),
+                .map(|s| format!("https://relay44.com/markets/{}", s)),
         ),
         Venue::Aerodrome => ("Aerodrome", None),
         Venue::Internal => ("Internal", None),
@@ -441,14 +441,10 @@ fn format_alert(
         format!("Mid: {:.2} | Liquidity: {}", mid, liquidity_str),
     ];
     if let Some(url) = link {
-        let label = match venue {
-            Venue::Limitless => "Open on Limitless",
-            _ => "Open on Polymarket",
-        };
+        let _ = venue;
         lines.push(format!(
-            "<a href=\"{}\">{}</a>",
+            "<a href=\"{}\">Trade on Relay44</a>",
             html_escape(&url),
-            label
         ));
     }
     lines.join("\n")
@@ -714,8 +710,8 @@ mod tests {
         assert!(s.contains("<b>Orderbook imbalance"));
         assert!(s.contains("Polymarket"));
         assert!(s.contains("Will BTC close above 100k?"));
-        assert!(s.contains("polymarket.com/market/btc-100k"));
-        assert!(s.contains("Open on Polymarket"));
+        assert!(s.contains("relay44.com/markets/btc-100k"));
+        assert!(s.contains("Trade on Relay44"));
         assert!(s.contains("5min EMA"));
         assert!(s.contains("Mid: 0.34"));
         assert!(s.contains("$12,400"));
@@ -739,8 +735,8 @@ mod tests {
             0.25,
         );
         assert!(s.contains("Limitless"));
-        assert!(s.contains("limitless.exchange/markets/eth-4k"));
-        assert!(s.contains("Open on Limitless"));
+        assert!(s.contains("relay44.com/markets/eth-4k"));
+        assert!(s.contains("Trade on Relay44"));
         assert!(s.contains("1/2.5x"));
     }
 

--- a/app/src/services/probability_alert.rs
+++ b/app/src/services/probability_alert.rs
@@ -395,8 +395,8 @@ mod tests {
         assert!(s.contains("Liquidity: $125.0k"));
         assert!(s.contains("24h vol: $3.4M"));
         assert!(s.contains("Category: politics"));
-        assert!(s.contains("https://polymarket.com/event/will-x"));
-        assert!(s.contains("Open on Polymarket"));
+        assert!(s.contains("https://relay44.com/markets/will-x"));
+        assert!(s.contains("Trade on Relay44"));
     }
 
     #[test]
@@ -414,7 +414,7 @@ mod tests {
     }
 
     #[test]
-    fn format_limitless_link_uses_limitless_domain() {
+    fn format_limitless_link_uses_relay44_domain() {
         let c = MarketContext {
             question: "Q".to_string(),
             slug: Some("lim-slug".to_string()),
@@ -423,8 +423,8 @@ mod tests {
             volume_24h_usd: None,
         };
         let s = format_alert(Some(&c), Venue::Limitless, "lim-slug:yes", 0.10, 0.15, 50.0);
-        assert!(s.contains("limitless.exchange/markets/lim-slug"));
-        assert!(s.contains("Open on Limitless"));
+        assert!(s.contains("relay44.com/markets/lim-slug"));
+        assert!(s.contains("Trade on Relay44"));
     }
 
     #[test]

--- a/app/src/services/telegram_commands.rs
+++ b/app/src/services/telegram_commands.rs
@@ -267,7 +267,7 @@ async fn top_text(state: &AppState, args: Option<&str>) -> String {
                 .enumerate()
                 .map(|(i, (q, slug, cat, score, liq))| {
                     let q = html_escape(&q);
-                    let url = format!("https://polymarket.com/event/{}", slug);
+                    let url = format!("https://relay44.com/markets/{}", slug);
                     let liq_s = liq.map(format_money).unwrap_or_else(|| "—".to_string());
                     format!(
                         "{}. <a href=\"{}\">{}</a>\n   score {:.2} · {} · liq {}",
@@ -310,7 +310,7 @@ async fn market_text(state: &AppState, args: Option<&str>) -> String {
 
     match row {
         Ok(Some((question, slug, category, yes, no, spread_bps, liq, vol))) => {
-            let url = format!("https://polymarket.com/event/{}", slug);
+            let url = format!("https://relay44.com/markets/{}", slug);
             let liq_s = liq.map(format_money).unwrap_or_else(|| "—".to_string());
             let vol_s = vol.map(format_money).unwrap_or_else(|| "—".to_string());
             format!(

--- a/app/src/services/telegram_format.rs
+++ b/app/src/services/telegram_format.rs
@@ -53,32 +53,34 @@ pub fn venue_title(venue: &str) -> &'static str {
     }
 }
 
-/// Builds the public market URL for a given venue/slug pair.
+/// Builds the Relay44 market URL for a given venue/slug pair. The slug is the
+/// same one scanners write to `market_venue_links` and the Next.js screener
+/// uses for `/markets/<slug>`, so alerts drive traffic back to the platform
+/// where users can actually trade instead of sending them to the upstream
+/// venue.
 ///
-/// Returns `None` when the slug is empty or the venue has no public URL
-/// convention. The slug is NOT html-escaped here — embedding the raw URL
-/// into an href attribute is the caller's responsibility (use
-/// `format_deep_link` for the full HTML link).
+/// Returns `None` when the slug is empty or the venue isn't one we index. The
+/// slug is NOT html-escaped here — embedding the raw URL into an href
+/// attribute is the caller's responsibility (use `format_deep_link` for the
+/// full HTML link).
 pub fn venue_link(venue: &str, slug: &str) -> Option<String> {
     if slug.is_empty() {
         return None;
     }
     match venue {
-        "polymarket" => Some(format!("https://polymarket.com/event/{}", slug)),
-        "limitless" => Some(format!("https://limitless.exchange/markets/{}", slug)),
+        "polymarket" | "limitless" => Some(format!("https://relay44.com/markets/{}", slug)),
         _ => None,
     }
 }
 
 /// Returns the HTML anchor line for the alert footer, e.g.
-/// `<a href="https://polymarket.com/event/abc">Open on Polymarket</a>`.
-/// Returns `None` when there's no public URL for this venue/slug.
+/// `<a href="https://relay44.com/markets/abc">Trade on Relay44</a>`.
+/// Returns `None` when there's no URL for this venue/slug.
 pub fn format_deep_link(venue: &str, slug: &str) -> Option<String> {
     let url = venue_link(venue, slug)?;
     Some(format!(
-        "<a href=\"{}\">Open on {}</a>",
+        "<a href=\"{}\">Trade on Relay44</a>",
         html_escape(&url),
-        venue_title(venue),
     ))
 }
 
@@ -199,14 +201,14 @@ mod tests {
     }
 
     #[test]
-    fn venue_link_builds_expected_urls() {
+    fn venue_link_builds_relay44_urls() {
         assert_eq!(
             venue_link("polymarket", "will-x"),
-            Some("https://polymarket.com/event/will-x".to_string())
+            Some("https://relay44.com/markets/will-x".to_string())
         );
         assert_eq!(
             venue_link("limitless", "some-slug"),
-            Some("https://limitless.exchange/markets/some-slug".to_string())
+            Some("https://relay44.com/markets/some-slug".to_string())
         );
     }
 
@@ -219,8 +221,8 @@ mod tests {
     #[test]
     fn deep_link_wraps_url_in_anchor() {
         let s = format_deep_link("polymarket", "abc").unwrap();
-        assert!(s.contains("href=\"https://polymarket.com/event/abc\""));
-        assert!(s.contains("Open on Polymarket"));
+        assert!(s.contains("href=\"https://relay44.com/markets/abc\""));
+        assert!(s.contains("Trade on Relay44"));
     }
 
     #[test]

--- a/app/src/services/volume_spike_alert.rs
+++ b/app/src/services/volume_spike_alert.rs
@@ -346,16 +346,14 @@ fn format_alert(
     vol_24h_total: f64,
 ) -> String {
     let ratio = if rate_1h > 0.0 { rate_5m / rate_1h } else { 0.0 };
-    let link = match venue {
-        Venue::Polymarket => format!("https://polymarket.com/event/{}", slug),
-        Venue::Limitless => format!("https://limitless.exchange/markets/{}", slug),
-    };
+    let link = format!("https://relay44.com/markets/{}", slug);
+    let _ = venue;
     format!(
         "🌊 <b>Volume spike — {header}</b>\n\
          <i>{question}</i>\n\n\
          Rate: <b>${rate_5m_fmt}/min</b> last 5m vs ${rate_1h_fmt}/min 1h baseline (<b>{ratio:.1}x</b>)\n\
          24h vol: ${vol_24h_fmt}\n\
-         <a href=\"{link}\">Open on {header}</a>",
+         <a href=\"{link}\">Trade on Relay44</a>",
         header = venue.header(),
         question = html_escape(question),
         rate_5m_fmt = format_money(rate_5m),
@@ -605,8 +603,8 @@ mod tests {
         assert!(s.contains("$180/min"));
         assert!(s.contains("<b>13.0x</b>"));
         assert!(s.contains("$485,200"));
-        assert!(s.contains("https://polymarket.com/event/btc-100k-eoy"));
-        assert!(s.contains("Open on Polymarket"));
+        assert!(s.contains("https://relay44.com/markets/btc-100k-eoy"));
+        assert!(s.contains("Trade on Relay44"));
     }
 
     #[test]
@@ -620,8 +618,8 @@ mod tests {
             12_345.0,
         );
         assert!(s.contains("<b>Volume spike — Limitless</b>"));
-        assert!(s.contains("https://limitless.exchange/markets/x-happen"));
-        assert!(s.contains("Open on Limitless"));
+        assert!(s.contains("https://relay44.com/markets/x-happen"));
+        assert!(s.contains("Trade on Relay44"));
         assert!(s.contains("<b>10.0x</b>"));
     }
 


### PR DESCRIPTION
## Summary
- Every Telegram alert CTA and read-only command (/top, /market) now links to `https://relay44.com/markets/<slug>` instead of the upstream `polymarket.com/event/<slug>` or `limitless.exchange/markets/<slug>`.
- Anchor text unified as **Trade on Relay44** so users land on our platform where they can actually trade.
- cross_venue_arb keeps its dual footer (PM side / LIM side) but both links point to Relay44 slugs, labeled "Trade PM side on Relay44" / "Trade LIM side on Relay44".
- Updated tests across volume_spike_alert, new_market_alert, probability_alert, cross_venue_arb, orderbook_imbalance_alert, telegram_format.

## Why now
Bot was advertising our competitors: alert CTAs were sending users to Polymarket/Limitless instead of Relay44. Fixes that so the whole alert surface drives traffic back to the platform.

## Test plan
- [ ] CI green (cargo check / clippy / test)
- [ ] Verify live alert after redeploy points to relay44.com/markets/<slug>