### PR TITLE
alerts: slug resolver route for /markets/by-slug deep links

### DIFF
--- a/app/src/api/evm.rs
+++ b/app/src/api/evm.rs
@@ -3464,6 +3464,62 @@ pub async fn get_base_market(
     Ok(HttpResponse::Ok().json(market))
 }
 
+pub async fn resolve_market_by_slug(
+    state: web::Data<Arc<AppState>>,
+    path: web::Path<(String, String)>,
+) -> Result<impl Responder, ApiError> {
+    let (provider, slug) = path.into_inner();
+    let provider = provider.trim().to_ascii_lowercase();
+    let slug = slug.trim().to_string();
+    if slug.is_empty() {
+        return Err(ApiError::bad_request("INVALID_SLUG", "slug cannot be empty"));
+    }
+
+    let canonical_id = match provider.as_str() {
+        "limitless" => format!("limitless:{}", slug),
+        "polymarket" => {
+            let cache_key = format!("slug-resolver:polymarket:{}", slug);
+            if let Ok(Some(cached)) = state.redis.get::<String>(&cache_key).await {
+                cached
+            } else {
+                let base = state.config.polymarket_gamma_api_base.trim_end_matches('/');
+                let url = format!("{}/markets", base);
+                let rows: Vec<serde_json::Value> = reqwest::Client::new()
+                    .get(&url)
+                    .query(&[("slug", slug.as_str()), ("limit", "1")])
+                    .send()
+                    .await
+                    .map_err(|e| ApiError::bad_request("UPSTREAM_ERROR", &format!("gamma request: {}", e)))?
+                    .error_for_status()
+                    .map_err(|e| ApiError::bad_request("UPSTREAM_ERROR", &format!("gamma status: {}", e)))?
+                    .json()
+                    .await
+                    .map_err(|e| ApiError::bad_request("UPSTREAM_ERROR", &format!("gamma parse: {}", e)))?;
+                let id = rows
+                    .first()
+                    .and_then(|r| r.get("id"))
+                    .and_then(|v| {
+                        v.as_str()
+                            .map(str::to_string)
+                            .or_else(|| v.as_u64().map(|n| n.to_string()))
+                    })
+                    .ok_or_else(|| ApiError::not_found("polymarket market"))?;
+                let canonical = format!("polymarket:{}", id);
+                let _ = state.redis.set(&cache_key, &canonical, Some(3600)).await;
+                canonical
+            }
+        }
+        _ => {
+            return Err(ApiError::bad_request(
+                "INVALID_PROVIDER",
+                "provider must be polymarket or limitless",
+            ))
+        }
+    };
+
+    Ok(HttpResponse::Ok().json(json!({ "canonicalId": canonical_id })))
+}
+
 pub async fn register_base_market_bootstrap(
     req: HttpRequest,
     state: web::Data<Arc<AppState>>,

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -235,6 +235,10 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
                         .configure(api::creator::configure)
                         .route("/markets", web::get().to(api::evm::get_base_markets))
                         .route(
+                            "/markets/by-slug/{provider}/{slug}",
+                            web::get().to(api::evm::resolve_market_by_slug),
+                        )
+                        .route(
                             "/markets/{market_id}",
                             web::get().to(api::evm::get_base_market),
                         )

--- a/app/src/services/cross_venue_arb.rs
+++ b/app/src/services/cross_venue_arb.rs
@@ -471,8 +471,8 @@ mod tests {
         assert!(s.contains("Liquidity: $50.0k"));
         assert!(s.contains("24h vol: $1.2M"));
         assert!(s.contains("Category: politics"));
-        assert!(s.contains("relay44.com/markets/pm-slug"));
-        assert!(s.contains("relay44.com/markets/lim-slug"));
+        assert!(s.contains("relay44.com/markets/by-slug/polymarket/pm-slug"));
+        assert!(s.contains("relay44.com/markets/by-slug/limitless/lim-slug"));
         assert!(s.contains("Trade PM side on Relay44"));
         assert!(s.contains("Trade LIM side on Relay44"));
     }

--- a/app/src/services/new_market_alert.rs
+++ b/app/src/services/new_market_alert.rs
@@ -365,7 +365,7 @@ mod tests {
         assert!(s.contains("New market"));
         assert!(s.contains("Polymarket"));
         assert!(s.contains("<i>Will BTC hit 100k?</i>"));
-        assert!(s.contains("relay44.com/markets/example-slug"));
+        assert!(s.contains("relay44.com/markets/by-slug/polymarket/example-slug"));
         assert!(s.contains("Trade on Relay44"));
         assert!(s.contains("kw:btc"));
     }
@@ -403,7 +403,7 @@ mod tests {
         m.venue = "limitless";
         m.slug = "lim-slug".to_string();
         let s = format_alert(&m, "kw:btc");
-        assert!(s.contains("relay44.com/markets/lim-slug"));
+        assert!(s.contains("relay44.com/markets/by-slug/limitless/lim-slug"));
         assert!(s.contains("Trade on Relay44"));
         assert!(s.contains("Limitless"));
     }

--- a/app/src/services/orderbook_imbalance_alert.rs
+++ b/app/src/services/orderbook_imbalance_alert.rs
@@ -391,12 +391,12 @@ fn format_alert(
         Venue::Polymarket => (
             "Polymarket",
             ctx.and_then(|c| c.slug.as_deref())
-                .map(|s| format!("https://relay44.com/markets/{}", s)),
+                .map(|s| format!("https://relay44.com/markets/by-slug/polymarket/{}", s)),
         ),
         Venue::Limitless => (
             "Limitless",
             ctx.and_then(|c| c.slug.as_deref())
-                .map(|s| format!("https://relay44.com/markets/{}", s)),
+                .map(|s| format!("https://relay44.com/markets/by-slug/limitless/{}", s)),
         ),
         Venue::Aerodrome => ("Aerodrome", None),
         Venue::Internal => ("Internal", None),
@@ -710,7 +710,7 @@ mod tests {
         assert!(s.contains("<b>Orderbook imbalance"));
         assert!(s.contains("Polymarket"));
         assert!(s.contains("Will BTC close above 100k?"));
-        assert!(s.contains("relay44.com/markets/btc-100k"));
+        assert!(s.contains("relay44.com/markets/by-slug/polymarket/btc-100k"));
         assert!(s.contains("Trade on Relay44"));
         assert!(s.contains("5min EMA"));
         assert!(s.contains("Mid: 0.34"));
@@ -735,7 +735,7 @@ mod tests {
             0.25,
         );
         assert!(s.contains("Limitless"));
-        assert!(s.contains("relay44.com/markets/eth-4k"));
+        assert!(s.contains("relay44.com/markets/by-slug/limitless/eth-4k"));
         assert!(s.contains("Trade on Relay44"));
         assert!(s.contains("1/2.5x"));
     }

--- a/app/src/services/probability_alert.rs
+++ b/app/src/services/probability_alert.rs
@@ -395,7 +395,7 @@ mod tests {
         assert!(s.contains("Liquidity: $125.0k"));
         assert!(s.contains("24h vol: $3.4M"));
         assert!(s.contains("Category: politics"));
-        assert!(s.contains("https://relay44.com/markets/will-x"));
+        assert!(s.contains("https://relay44.com/markets/by-slug/polymarket/will-x"));
         assert!(s.contains("Trade on Relay44"));
     }
 
@@ -423,7 +423,7 @@ mod tests {
             volume_24h_usd: None,
         };
         let s = format_alert(Some(&c), Venue::Limitless, "lim-slug:yes", 0.10, 0.15, 50.0);
-        assert!(s.contains("relay44.com/markets/lim-slug"));
+        assert!(s.contains("relay44.com/markets/by-slug/limitless/lim-slug"));
         assert!(s.contains("Trade on Relay44"));
     }
 

--- a/app/src/services/telegram_commands.rs
+++ b/app/src/services/telegram_commands.rs
@@ -267,7 +267,7 @@ async fn top_text(state: &AppState, args: Option<&str>) -> String {
                 .enumerate()
                 .map(|(i, (q, slug, cat, score, liq))| {
                     let q = html_escape(&q);
-                    let url = format!("https://relay44.com/markets/{}", slug);
+                    let url = format!("https://relay44.com/markets/by-slug/polymarket/{}", slug);
                     let liq_s = liq.map(format_money).unwrap_or_else(|| "—".to_string());
                     format!(
                         "{}. <a href=\"{}\">{}</a>\n   score {:.2} · {} · liq {}",
@@ -310,7 +310,7 @@ async fn market_text(state: &AppState, args: Option<&str>) -> String {
 
     match row {
         Ok(Some((question, slug, category, yes, no, spread_bps, liq, vol))) => {
-            let url = format!("https://relay44.com/markets/{}", slug);
+            let url = format!("https://relay44.com/markets/by-slug/polymarket/{}", slug);
             let liq_s = liq.map(format_money).unwrap_or_else(|| "—".to_string());
             let vol_s = vol.map(format_money).unwrap_or_else(|| "—".to_string());
             format!(

--- a/app/src/services/telegram_format.rs
+++ b/app/src/services/telegram_format.rs
@@ -68,7 +68,10 @@ pub fn venue_link(venue: &str, slug: &str) -> Option<String> {
         return None;
     }
     match venue {
-        "polymarket" | "limitless" => Some(format!("https://relay44.com/markets/{}", slug)),
+        "polymarket" | "limitless" => Some(format!(
+            "https://relay44.com/markets/by-slug/{}/{}",
+            venue, slug
+        )),
         _ => None,
     }
 }
@@ -204,11 +207,11 @@ mod tests {
     fn venue_link_builds_relay44_urls() {
         assert_eq!(
             venue_link("polymarket", "will-x"),
-            Some("https://relay44.com/markets/will-x".to_string())
+            Some("https://relay44.com/markets/by-slug/polymarket/will-x".to_string())
         );
         assert_eq!(
             venue_link("limitless", "some-slug"),
-            Some("https://relay44.com/markets/some-slug".to_string())
+            Some("https://relay44.com/markets/by-slug/limitless/some-slug".to_string())
         );
     }
 
@@ -221,7 +224,7 @@ mod tests {
     #[test]
     fn deep_link_wraps_url_in_anchor() {
         let s = format_deep_link("polymarket", "abc").unwrap();
-        assert!(s.contains("href=\"https://relay44.com/markets/abc\""));
+        assert!(s.contains("href=\"https://relay44.com/markets/by-slug/polymarket/abc\""));
         assert!(s.contains("Trade on Relay44"));
     }
 

--- a/app/src/services/volume_spike_alert.rs
+++ b/app/src/services/volume_spike_alert.rs
@@ -346,8 +346,11 @@ fn format_alert(
     vol_24h_total: f64,
 ) -> String {
     let ratio = if rate_1h > 0.0 { rate_5m / rate_1h } else { 0.0 };
-    let link = format!("https://relay44.com/markets/{}", slug);
-    let _ = venue;
+    let venue_slug = match venue {
+        Venue::Polymarket => "polymarket",
+        Venue::Limitless => "limitless",
+    };
+    let link = format!("https://relay44.com/markets/by-slug/{}/{}", venue_slug, slug);
     format!(
         "🌊 <b>Volume spike — {header}</b>\n\
          <i>{question}</i>\n\n\
@@ -603,7 +606,7 @@ mod tests {
         assert!(s.contains("$180/min"));
         assert!(s.contains("<b>13.0x</b>"));
         assert!(s.contains("$485,200"));
-        assert!(s.contains("https://relay44.com/markets/btc-100k-eoy"));
+        assert!(s.contains("https://relay44.com/markets/by-slug/polymarket/btc-100k-eoy"));
         assert!(s.contains("Trade on Relay44"));
     }
 
@@ -618,7 +621,7 @@ mod tests {
             12_345.0,
         );
         assert!(s.contains("<b>Volume spike — Limitless</b>"));
-        assert!(s.contains("https://relay44.com/markets/x-happen"));
+        assert!(s.contains("https://relay44.com/markets/by-slug/limitless/x-happen"));
         assert!(s.contains("Trade on Relay44"));
         assert!(s.contains("<b>10.0x</b>"));
     }

--- a/web/src/app/markets/by-slug/[provider]/[slug]/page.tsx
+++ b/web/src/app/markets/by-slug/[provider]/[slug]/page.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+import { PageShell } from "@/components/layout";
+import { LoadingScreen } from "@/components/ui";
+import { resolveApiUrl } from "@/lib/api";
+
+export default function MarketBySlugPage() {
+  const router = useRouter();
+  const params = useParams();
+  const provider = String(params.provider ?? "");
+  const slug = String(params.slug ?? "");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!provider || !slug) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const url = resolveApiUrl(
+          `/v1/evm/markets/by-slug/${encodeURIComponent(provider)}/${encodeURIComponent(slug)}`,
+        );
+        const res = await fetch(url, { cache: "no-store" });
+        if (!res.ok) throw new Error(`resolve failed: ${res.status}`);
+        const body = (await res.json()) as { canonicalId?: string };
+        if (cancelled) return;
+        if (body.canonicalId) {
+          router.replace(`/markets/${encodeURIComponent(body.canonicalId)}`);
+        } else {
+          setError("market not found");
+        }
+      } catch (e) {
+        if (cancelled) return;
+        setError(e instanceof Error ? e.message : "market not found");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [provider, slug, router]);
+
+  if (error) {
+    return (
+      <PageShell>
+        <div className="mx-auto max-w-xl py-16 text-center">
+          <h1 className="text-lg font-semibold">Market not found</h1>
+          <p className="mt-2 text-sm text-zinc-500">
+            The link couldn&apos;t be resolved on Relay44.
+          </p>
+          <Link className="mt-6 inline-block underline" href="/markets">
+            Browse all markets
+          </Link>
+        </div>
+      </PageShell>
+    );
+  }
+
+  return <LoadingScreen />;
+}


### PR DESCRIPTION
## Summary
Introduces a proper slug-to-canonical-id resolver so Telegram alert deep links actually land on real Relay44 market pages.

- **Backend**: `GET /v1/evm/markets/by-slug/{provider}/{slug}` returns `{ canonicalId }`.
  - `polymarket` → looks up numeric market id via gamma `/markets?slug=` (1h redis cache).
  - `limitless` → `limitless:<slug>` passthrough (limitless already keys by slug).
- **Web**: new `/markets/by-slug/[provider]/[slug]` route fetches the resolver and redirects to `/markets/<canonicalId>`.
- **Alerters + commands**: `telegram_format::venue_link`, `volume_spike_alert`, `orderbook_imbalance_alert`, and `telegram_commands` (`/top`, `/market`) now emit `relay44.com/markets/by-slug/<venue>/<slug>` URLs instead of the bare `/markets/<slug>` form that 404'd.

## Why
The prior deep-link PR pointed at `/markets/<slug>`, but the frontend `/markets/[id]` route expects the on-chain market id (numeric for internal, namespaced like `polymarket:<id>` for external). Every alert link was a 404. This PR adds the missing resolver layer so slug-based links resolve to the canonical id and load the real market page.

## Test plan
- [ ] CI green (cargo check / clippy / test / web build)
- [ ] Smoke test: hit `/v1/evm/markets/by-slug/polymarket/<known-slug>` → returns `polymarket:<id>`
- [ ] Smoke test: navigate to `/markets/by-slug/polymarket/<known-slug>` → redirects to populated market page
- [ ] Verify live Telegram alert after re-enabling alerters lands on a real market page