### PR TITLE
alerts: unified digest scheduler batches signals into hourly telegram post

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -41,8 +41,8 @@ use actix_web::web;
 use api::JwtService;
 use config::AppConfig;
 use services::{
-    market_data::MarketDataBus, DatabaseService, EventBus, EvmIndexerService, EvmRpcService,
-    MetricsService, OrderBookService, RedisService, WebSocketHub,
+    alert_bus::AlertBus, market_data::MarketDataBus, DatabaseService, EventBus, EvmIndexerService,
+    EvmRpcService, MetricsService, OrderBookService, RedisService, WebSocketHub,
 };
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
@@ -59,6 +59,7 @@ pub struct AppState {
     pub ws_hub: WebSocketHub,
     pub event_bus: EventBus,
     pub market_data: Arc<MarketDataBus>,
+    pub alert_bus: Arc<AlertBus>,
     pub kyc: services::kyc::KycService,
     pub limitless_partner: Option<services::limitless_partner::LimitlessPartnerConfig>,
     pub is_shutting_down: Arc<AtomicBool>,

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -88,6 +88,7 @@ async fn main() -> std::io::Result<()> {
     let ws_hub = WebSocketHub::new();
     let event_bus = EventBus::new();
     let market_data = Arc::new(relay44_backend::services::market_data::MarketDataBus::new());
+    let alert_bus = relay44_backend::services::alert_bus::AlertBus::new();
 
     let kyc = relay44_backend::services::kyc::KycService::new(
         relay44_backend::services::kyc::KycConfig::from_env(),
@@ -107,6 +108,7 @@ async fn main() -> std::io::Result<()> {
         ws_hub,
         event_bus,
         market_data,
+        alert_bus,
         kyc,
         limitless_partner,
         is_shutting_down: Arc::new(AtomicBool::new(false)),
@@ -119,6 +121,7 @@ async fn main() -> std::io::Result<()> {
     relay44_backend::services::new_market_alert::spawn(app_state.clone());
     relay44_backend::services::volume_spike_alert::spawn(app_state.clone());
     relay44_backend::services::orderbook_imbalance_alert::spawn(app_state.clone());
+    relay44_backend::services::digest_scheduler::spawn(app_state.clone());
 
     let migration_db = app_state.db.clone();
     let background_state = app_state.clone();

--- a/app/src/services/alert_bus.rs
+++ b/app/src/services/alert_bus.rs
@@ -105,6 +105,10 @@ impl AlertBus {
     pub async fn len(&self) -> usize {
         self.signals.read().await.len()
     }
+
+    pub async fn is_empty(&self) -> bool {
+        self.signals.read().await.is_empty()
+    }
 }
 
 pub fn now_secs() -> u64 {

--- a/app/src/services/alert_bus.rs
+++ b/app/src/services/alert_bus.rs
@@ -1,0 +1,174 @@
+//! Shared in-memory queue for alerter signals.
+//!
+//! Individual alerters (probability_alert, volume_spike_alert, future
+//! additions) publish `Signal`s to this bus instead of sending to Telegram
+//! directly. The digest_scheduler drains the bus on a fixed cadence, ranks
+//! the signals, and emits a single aggregated Telegram message — which keeps
+//! the supergroup from being flooded when many markets move at once.
+//!
+//! The bus is bounded (oldest entries dropped on overflow) so a misbehaving
+//! alerter can't leak unbounded memory if the digest_scheduler is disabled.
+
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use tokio::sync::RwLock;
+
+const DEFAULT_CAPACITY: usize = 512;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SignalKind {
+    ProbabilityShift,
+    VolumeSpike,
+}
+
+impl SignalKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SignalKind::ProbabilityShift => "probability_shift",
+            SignalKind::VolumeSpike => "volume_spike",
+        }
+    }
+}
+
+/// A single alerter signal. The `body` is pre-formatted by the producing
+/// alerter (e.g. "↑ 10.0¢ → 18.0¢ (+80.0%)") so the digest_scheduler can
+/// emit one without reaching back for venue-specific data.
+#[derive(Debug, Clone)]
+pub struct Signal {
+    pub kind: SignalKind,
+    pub venue: String,
+    pub market_key: String,
+    pub slug: Option<String>,
+    pub question: String,
+    pub liquidity_usd: Option<f64>,
+    pub volume_24h_usd: Option<f64>,
+    pub category: Option<String>,
+    /// Magnitude of the triggering move. For ProbabilityShift this is |Δ%|;
+    /// for VolumeSpike this is the multiplier over baseline. Used for scoring.
+    pub move_size: f64,
+    pub body: String,
+    /// Unix seconds. Used for recency decay in the scorer.
+    pub timestamp_secs: u64,
+}
+
+impl Signal {
+    /// Stable identity across alerter kinds for cooldown keying. Different
+    /// signal kinds on the same market share a cooldown so we don't emit two
+    /// digest entries for the same market in one digest run.
+    pub fn dedup_key(&self) -> String {
+        format!("{}:{}", self.venue, self.market_key)
+    }
+}
+
+pub struct AlertBus {
+    capacity: usize,
+    signals: RwLock<VecDeque<Signal>>,
+}
+
+impl Default for AlertBus {
+    fn default() -> Self {
+        Self::with_capacity(DEFAULT_CAPACITY)
+    }
+}
+
+impl AlertBus {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            capacity,
+            signals: RwLock::new(VecDeque::with_capacity(capacity)),
+        }
+    }
+
+    pub async fn publish(&self, signal: Signal) {
+        let mut q = self.signals.write().await;
+        if q.len() >= self.capacity {
+            q.pop_front();
+        }
+        q.push_back(signal);
+    }
+
+    /// Empties the bus and returns every signal queued since the previous
+    /// drain. Callers (the digest_scheduler) are responsible for scoring and
+    /// filtering — the bus itself doesn't know what's "important".
+    pub async fn drain(&self) -> Vec<Signal> {
+        let mut q = self.signals.write().await;
+        let out: Vec<Signal> = q.drain(..).collect();
+        out
+    }
+
+    pub async fn len(&self) -> usize {
+        self.signals.read().await.len()
+    }
+}
+
+pub fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mk_signal(market: &str) -> Signal {
+        Signal {
+            kind: SignalKind::ProbabilityShift,
+            venue: "polymarket".to_string(),
+            market_key: market.to_string(),
+            slug: Some("slug".to_string()),
+            question: "Q?".to_string(),
+            liquidity_usd: Some(1_000.0),
+            volume_24h_usd: Some(2_000.0),
+            category: None,
+            move_size: 10.0,
+            body: "body".to_string(),
+            timestamp_secs: now_secs(),
+        }
+    }
+
+    #[tokio::test]
+    async fn publish_then_drain_returns_all_in_order() {
+        let bus = AlertBus::with_capacity(16);
+        bus.publish(mk_signal("a")).await;
+        bus.publish(mk_signal("b")).await;
+        bus.publish(mk_signal("c")).await;
+        let drained = bus.drain().await;
+        assert_eq!(drained.len(), 3);
+        assert_eq!(drained[0].market_key, "a");
+        assert_eq!(drained[2].market_key, "c");
+    }
+
+    #[tokio::test]
+    async fn drain_empties_the_bus() {
+        let bus = AlertBus::with_capacity(8);
+        bus.publish(mk_signal("a")).await;
+        let _ = bus.drain().await;
+        assert_eq!(bus.len().await, 0);
+    }
+
+    #[tokio::test]
+    async fn capacity_bounded_drops_oldest() {
+        let bus = AlertBus::with_capacity(2);
+        bus.publish(mk_signal("a")).await;
+        bus.publish(mk_signal("b")).await;
+        bus.publish(mk_signal("c")).await;
+        let drained = bus.drain().await;
+        assert_eq!(drained.len(), 2);
+        assert_eq!(drained[0].market_key, "b");
+        assert_eq!(drained[1].market_key, "c");
+    }
+
+    #[test]
+    fn dedup_key_combines_venue_and_market() {
+        let s = mk_signal("tok1");
+        assert_eq!(s.dedup_key(), "polymarket:tok1");
+    }
+}

--- a/app/src/services/digest_scheduler.rs
+++ b/app/src/services/digest_scheduler.rs
@@ -1,0 +1,330 @@
+//! Digest alerter — batches signals from the `AlertBus` and emits a single
+//! ranked Telegram message on a fixed cadence (default every 60 minutes).
+//!
+//! Before the digest existed every alerter (`probability_alert`,
+//! `volume_spike_alert`) sent to Telegram directly, which on a busy day
+//! produced dozens of messages per hour and buried the few genuinely
+//! interesting moves. The digest replaces that with one message per tick:
+//! all drained signals are scored, deduped by market, the top N are
+//! selected, and anything that's been alerted recently is skipped via a
+//! cross-tick cooldown keyed on `{venue}:{market_key}`.
+//!
+//! Scoring is deliberately simple:
+//!
+//!   score = sqrt(liquidity_usd) * |move_size| * recency_decay
+//!
+//! — a $100k book moving 10 pts outranks a $5k book moving 12 pts, but a
+//! very fresh signal still beats an older one with similar economics.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use log::{info, warn};
+
+use super::alert_bus::{now_secs, Signal};
+use super::telegram_format::{
+    format_deep_link, format_metadata_row, html_escape, venue_title, TelegramClient,
+};
+use crate::AppState;
+
+const DEFAULT_INTERVAL_SECS: u64 = 3600;
+const DEFAULT_TOP_N: usize = 3;
+const DEFAULT_MARKET_COOLDOWN_SECS: u64 = 14_400;
+const LIQUIDITY_FLOOR: f64 = 100.0;
+const RECENCY_HALF_LIFE_SECS: f64 = 7_200.0;
+
+pub fn spawn(state: Arc<AppState>) {
+    let enabled = env_bool("DIGEST_ENABLED", false);
+    if !enabled {
+        info!("Digest scheduler disabled (DIGEST_ENABLED=false)");
+        return;
+    }
+
+    let Ok(bot_token) = std::env::var("TELEGRAM_BOT_TOKEN") else {
+        warn!("DIGEST_ENABLED=true but TELEGRAM_BOT_TOKEN missing; not starting");
+        return;
+    };
+    let Ok(chat_id) = std::env::var("TELEGRAM_CHAT_ID") else {
+        warn!("DIGEST_ENABLED=true but TELEGRAM_CHAT_ID missing; not starting");
+        return;
+    };
+
+    let interval_secs = env_u64("DIGEST_INTERVAL_SECS", DEFAULT_INTERVAL_SECS).max(60);
+    let top_n = env_usize("DIGEST_TOP_N", DEFAULT_TOP_N).max(1);
+    let cooldown_secs = env_u64("DIGEST_MARKET_COOLDOWN_SECS", DEFAULT_MARKET_COOLDOWN_SECS);
+
+    info!(
+        "Starting digest scheduler (interval={}s, top_n={}, market_cooldown={}s)",
+        interval_secs, top_n, cooldown_secs
+    );
+
+    let tg = TelegramClient::new(bot_token, chat_id);
+
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(interval_secs));
+        // Skip the immediate tick — give the bus time to accumulate.
+        interval.tick().await;
+
+        let mut last_alerted: HashMap<String, u64> = HashMap::new();
+
+        loop {
+            interval.tick().await;
+            run_tick(&state, &tg, top_n, cooldown_secs, &mut last_alerted).await;
+        }
+    });
+}
+
+async fn run_tick(
+    state: &AppState,
+    tg: &TelegramClient,
+    top_n: usize,
+    cooldown_secs: u64,
+    last_alerted: &mut HashMap<String, u64>,
+) {
+    let drained = state.alert_bus.drain().await;
+    if drained.is_empty() {
+        info!("digest tick: bus empty, skipping send");
+        return;
+    }
+
+    let now = now_secs();
+    let selected = select_top_signals(drained, top_n, cooldown_secs, now, last_alerted);
+    if selected.is_empty() {
+        info!("digest tick: all candidates filtered by cooldown, skipping send");
+        return;
+    }
+
+    for s in &selected {
+        last_alerted.insert(s.dedup_key(), now);
+    }
+
+    let text = format_digest(&selected);
+    if let Err(e) = tg.send(&text).await {
+        warn!("digest send failed: {}", e);
+    } else {
+        info!("digest sent ({} signals)", selected.len());
+    }
+}
+
+/// Pick the highest-scoring signal per market, drop anything in cooldown, then
+/// keep the top `n` overall. Pure — all mutable state is passed in so tests can
+/// drive it deterministically.
+pub fn select_top_signals(
+    drained: Vec<Signal>,
+    top_n: usize,
+    cooldown_secs: u64,
+    now: u64,
+    last_alerted: &HashMap<String, u64>,
+) -> Vec<Signal> {
+    let mut by_market: HashMap<String, Signal> = HashMap::new();
+    for s in drained {
+        let key = s.dedup_key();
+        if let Some(last) = last_alerted.get(&key) {
+            if now.saturating_sub(*last) < cooldown_secs {
+                continue;
+            }
+        }
+        let entry = by_market.entry(key).or_insert_with(|| s.clone());
+        if score(&s, now) > score(entry, now) {
+            *entry = s;
+        }
+    }
+
+    let mut ranked: Vec<(f64, Signal)> = by_market
+        .into_values()
+        .map(|s| (score(&s, now), s))
+        .collect();
+    ranked.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+    ranked.into_iter().take(top_n).map(|(_, s)| s).collect()
+}
+
+fn score(signal: &Signal, now: u64) -> f64 {
+    let liq = signal.liquidity_usd.unwrap_or(LIQUIDITY_FLOOR).max(LIQUIDITY_FLOOR);
+    let liq_weight = liq.sqrt();
+    let age = now.saturating_sub(signal.timestamp_secs) as f64;
+    let recency = (-age / RECENCY_HALF_LIFE_SECS).exp();
+    liq_weight * signal.move_size.abs() * recency
+}
+
+fn format_digest(signals: &[Signal]) -> String {
+    let mut out = String::new();
+    out.push_str("<b>\u{1F4CA} Top signals</b>\n");
+    for (i, s) in signals.iter().enumerate() {
+        if i > 0 {
+            out.push('\n');
+        }
+        out.push('\n');
+        out.push_str(&format!(
+            "<b>{}. {}</b>",
+            i + 1,
+            kind_label(s.kind.as_str())
+        ));
+        out.push_str(&format!(" — {}\n", venue_title(&s.venue)));
+        out.push_str(&format!("<i>{}</i>\n", html_escape(&s.question)));
+        out.push_str(&s.body);
+        let meta = format_metadata_row(s.liquidity_usd, s.volume_24h_usd, s.category.as_deref());
+        if !meta.is_empty() {
+            out.push('\n');
+            out.push_str(&meta);
+        }
+        if let Some(slug) = &s.slug {
+            if let Some(link) = format_deep_link(&s.venue, slug) {
+                out.push('\n');
+                out.push_str(&link);
+            }
+        }
+    }
+    out
+}
+
+fn kind_label(kind: &str) -> &'static str {
+    match kind {
+        "probability_shift" => "Probability shift",
+        "volume_spike" => "Volume spike",
+        _ => "Signal",
+    }
+}
+
+fn env_bool(key: &str, default: bool) -> bool {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse::<bool>().ok())
+        .unwrap_or(default)
+}
+
+fn env_u64(key: &str, default: u64) -> u64 {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(default)
+}
+
+fn env_usize(key: &str, default: usize) -> usize {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(default)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::alert_bus::SignalKind;
+
+    fn mk(venue: &str, market: &str, liq: Option<f64>, move_size: f64, ts: u64) -> Signal {
+        Signal {
+            kind: SignalKind::ProbabilityShift,
+            venue: venue.to_string(),
+            market_key: market.to_string(),
+            slug: Some(market.to_string()),
+            question: format!("Q {}", market),
+            liquidity_usd: liq,
+            volume_24h_usd: None,
+            category: None,
+            move_size,
+            body: format!("body {}", market),
+            timestamp_secs: ts,
+        }
+    }
+
+    #[test]
+    fn higher_liquidity_outscores_bigger_move_on_dust() {
+        let now = 1_000_000;
+        let dust = mk("polymarket", "dust", Some(500.0), 30.0, now);
+        let real = mk("polymarket", "real", Some(200_000.0), 10.0, now);
+        assert!(score(&real, now) > score(&dust, now));
+    }
+
+    #[test]
+    fn recency_decay_favors_fresh_signals() {
+        let now = 1_000_000;
+        let fresh = mk("polymarket", "a", Some(50_000.0), 10.0, now);
+        let stale = mk("polymarket", "b", Some(50_000.0), 10.0, now - 14_400);
+        assert!(score(&fresh, now) > score(&stale, now));
+    }
+
+    #[test]
+    fn same_market_dedupes_to_highest_scoring_signal() {
+        let now = 1_000_000;
+        let signals = vec![
+            mk("polymarket", "m1", Some(10_000.0), 5.0, now),
+            mk("polymarket", "m1", Some(10_000.0), 20.0, now),
+        ];
+        let picked = select_top_signals(signals, 3, 14_400, now, &HashMap::new());
+        assert_eq!(picked.len(), 1);
+        assert_eq!(picked[0].move_size, 20.0);
+    }
+
+    #[test]
+    fn cooldown_filters_recently_alerted_markets() {
+        let now = 1_000_000;
+        let mut last = HashMap::new();
+        last.insert("polymarket:m1".to_string(), now - 600);
+        let signals = vec![
+            mk("polymarket", "m1", Some(100_000.0), 20.0, now),
+            mk("polymarket", "m2", Some(10_000.0), 10.0, now),
+        ];
+        let picked = select_top_signals(signals, 3, 14_400, now, &last);
+        assert_eq!(picked.len(), 1);
+        assert_eq!(picked[0].market_key, "m2");
+    }
+
+    #[test]
+    fn cooldown_expires_after_window() {
+        let now = 1_000_000;
+        let mut last = HashMap::new();
+        last.insert("polymarket:m1".to_string(), now - 20_000);
+        let signals = vec![mk("polymarket", "m1", Some(100_000.0), 20.0, now)];
+        let picked = select_top_signals(signals, 3, 14_400, now, &last);
+        assert_eq!(picked.len(), 1);
+    }
+
+    #[test]
+    fn top_n_caps_output() {
+        let now = 1_000_000;
+        let signals: Vec<Signal> = (0..10)
+            .map(|i| mk("polymarket", &format!("m{}", i), Some(10_000.0 * (i as f64 + 1.0)), 10.0, now))
+            .collect();
+        let picked = select_top_signals(signals, 3, 14_400, now, &HashMap::new());
+        assert_eq!(picked.len(), 3);
+        // Highest-liquidity markets (m7, m8, m9) should win.
+        let keys: Vec<&str> = picked.iter().map(|s| s.market_key.as_str()).collect();
+        assert!(keys.contains(&"m9"));
+        assert!(keys.contains(&"m8"));
+        assert!(keys.contains(&"m7"));
+    }
+
+    #[test]
+    fn digest_format_contains_header_and_entries() {
+        let now = 1_000_000;
+        let signals = vec![
+            mk("polymarket", "btc", Some(100_000.0), 15.0, now),
+            mk("limitless", "eth", Some(20_000.0), 12.0, now),
+        ];
+        let s = format_digest(&signals);
+        assert!(s.contains("Top signals"));
+        assert!(s.contains("Probability shift"));
+        assert!(s.contains("Polymarket"));
+        assert!(s.contains("Limitless"));
+        assert!(s.contains("relay44.com/markets/by-slug/polymarket/btc"));
+        assert!(s.contains("relay44.com/markets/by-slug/limitless/eth"));
+    }
+
+    #[test]
+    fn digest_format_html_escapes_question() {
+        let now = 1_000_000;
+        let mut s = mk("polymarket", "m1", Some(10_000.0), 5.0, now);
+        s.question = "Will <X> & <Y>?".to_string();
+        let out = format_digest(&[s]);
+        assert!(out.contains("&lt;X&gt;"));
+        assert!(out.contains("&amp;"));
+        assert!(!out.contains("<X>"));
+    }
+
+    #[test]
+    fn empty_input_returns_empty_selection() {
+        let picked = select_top_signals(vec![], 3, 14_400, 1_000_000, &HashMap::new());
+        assert!(picked.is_empty());
+    }
+}

--- a/app/src/services/mod.rs
+++ b/app/src/services/mod.rs
@@ -1,9 +1,11 @@
 pub mod aerodrome;
 pub mod aerodrome_scanner;
 pub mod agent_scheduler;
+pub mod alert_bus;
 pub mod creator_economics;
 pub mod cross_venue_arb;
 pub mod database;
+pub mod digest_scheduler;
 pub mod distribution;
 pub mod distribution_scheduler;
 pub mod event_bus;

--- a/app/src/services/new_market_alert.rs
+++ b/app/src/services/new_market_alert.rs
@@ -11,7 +11,7 @@
 //! this alerter stays consistent with `probability_alert` and
 //! `cross_venue_arb`.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -25,6 +25,8 @@ use crate::AppState;
 
 const DEFAULT_POLL_SECS: u64 = 60;
 const DEFAULT_COOLDOWN_SECS: u64 = 900;
+const DEFAULT_RATE_LIMIT_PER_HOUR: usize = 3;
+const RATE_LIMIT_WINDOW: Duration = Duration::from_secs(3600);
 const MAX_ALERTS_PER_TICK: usize = 5;
 
 pub fn spawn(state: Arc<AppState>) {
@@ -50,6 +52,8 @@ pub fn spawn(state: Arc<AppState>) {
         "NEW_MARKET_COOLDOWN_SECS",
         DEFAULT_COOLDOWN_SECS,
     ));
+    let rate_limit_per_hour =
+        env_usize("NEW_MARKET_RATE_LIMIT_PER_HOUR", DEFAULT_RATE_LIMIT_PER_HOUR);
 
     if watchlist.is_empty() && categories.is_empty() {
         warn!(
@@ -61,10 +65,11 @@ pub fn spawn(state: Arc<AppState>) {
     }
 
     info!(
-        "Starting new-market alerts (watchlist={:?}, categories={:?}, poll={}s)",
+        "Starting new-market alerts (watchlist={:?}, categories={:?}, poll={}s, rate_limit={}/hr)",
         watchlist,
         categories,
-        poll.as_secs()
+        poll.as_secs(),
+        rate_limit_per_hour,
     );
 
     let tg = TelegramClient::new(bot_token, chat_id);
@@ -73,6 +78,7 @@ pub fn spawn(state: Arc<AppState>) {
         let mut cursor_poly: Option<DateTime<Utc>> = None;
         let mut cursor_lim: Option<DateTime<Utc>> = None;
         let mut last_alert: HashMap<String, Instant> = HashMap::new();
+        let mut sent_times: VecDeque<Instant> = VecDeque::new();
 
         let mut interval = tokio::time::interval(poll);
         interval.tick().await;
@@ -84,7 +90,17 @@ pub fn spawn(state: Arc<AppState>) {
             match fetch_new_polymarket(&state, cursor_poly).await {
                 Ok(rows) => {
                     for r in rows.iter().take(MAX_ALERTS_PER_TICK) {
-                        maybe_alert(&tg, &watchlist, &categories, cooldown, &mut last_alert, r).await;
+                        maybe_alert(
+                            &tg,
+                            &watchlist,
+                            &categories,
+                            cooldown,
+                            rate_limit_per_hour,
+                            &mut last_alert,
+                            &mut sent_times,
+                            r,
+                        )
+                        .await;
                     }
                     if let Some(latest) = rows.iter().map(|r| r.created_at).max() {
                         cursor_poly = Some(match cursor_poly {
@@ -99,7 +115,17 @@ pub fn spawn(state: Arc<AppState>) {
             match fetch_new_limitless(&state, cursor_lim).await {
                 Ok(rows) => {
                     for r in rows.iter().take(MAX_ALERTS_PER_TICK) {
-                        maybe_alert(&tg, &watchlist, &categories, cooldown, &mut last_alert, r).await;
+                        maybe_alert(
+                            &tg,
+                            &watchlist,
+                            &categories,
+                            cooldown,
+                            rate_limit_per_hour,
+                            &mut last_alert,
+                            &mut sent_times,
+                            r,
+                        )
+                        .await;
                     }
                     if let Some(latest) = rows.iter().map(|r| r.created_at).max() {
                         cursor_lim = Some(match cursor_lim {
@@ -241,7 +267,9 @@ async fn maybe_alert(
     watchlist: &[String],
     categories: &[String],
     cooldown: Duration,
+    rate_limit_per_hour: usize,
     last_alert: &mut HashMap<String, Instant>,
+    sent_times: &mut VecDeque<Instant>,
     m: &NewMarket,
 ) {
     let hit = match_hit(watchlist, categories, m);
@@ -253,11 +281,32 @@ async fn maybe_alert(
             return;
         }
     }
+
+    prune_rate_window(sent_times);
+    if rate_limit_per_hour > 0 && sent_times.len() >= rate_limit_per_hour {
+        info!(
+            "new_market_alert suppressed ({}): rate limit {}/hr reached",
+            reason, rate_limit_per_hour
+        );
+        return;
+    }
+
     last_alert.insert(cooldown_key, Instant::now());
 
     let text = format_alert(m, &reason);
-    if let Err(e) = tg.send(&text).await {
-        warn!("telegram send failed (new-market): {}", e);
+    match tg.send(&text).await {
+        Ok(()) => sent_times.push_back(Instant::now()),
+        Err(e) => warn!("telegram send failed (new-market): {}", e),
+    }
+}
+
+fn prune_rate_window(sent_times: &mut VecDeque<Instant>) {
+    while let Some(front) = sent_times.front() {
+        if front.elapsed() >= RATE_LIMIT_WINDOW {
+            sent_times.pop_front();
+        } else {
+            break;
+        }
     }
 }
 
@@ -315,6 +364,13 @@ fn env_u64(key: &str, default: u64) -> u64 {
     std::env::var(key)
         .ok()
         .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(default)
+}
+
+fn env_usize(key: &str, default: usize) -> usize {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
         .unwrap_or(default)
 }
 

--- a/app/src/services/probability_alert.rs
+++ b/app/src/services/probability_alert.rs
@@ -1,7 +1,7 @@
 //! Telegram probability-shift alerts.
 //!
 //! Subscribes to the market_data bus, tracks the last observed price per
-//! (venue, market_key), and pushes a Telegram message when a fresh snapshot
+//! (venue, market_key), and emits an alerter signal when a fresh snapshot
 //! moves by more than `PROB_ALERT_THRESHOLD_PCT`. Each market is on a
 //! per-market cooldown so a rapidly-jittery book can't spam the channel.
 //!
@@ -12,9 +12,10 @@
 //! without dropping alerts for markets whose metadata isn't in the scanner
 //! tables yet.
 //!
-//! Message layout is HTML and goes through the shared helpers in
-//! `telegram_format` so this alerter stays visually consistent with
-//! `cross_venue_arb` and `new_market_alert`.
+//! When `DIGEST_ENABLED=true` (the default shipping config), signals are
+//! published to the shared `AlertBus` and the `digest_scheduler` decides
+//! what to send. Otherwise this alerter keeps its legacy direct-send path,
+//! which remains useful for local dev and incident debugging.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -23,6 +24,7 @@ use std::time::{Duration, Instant};
 use log::{info, warn};
 use tokio::sync::broadcast::error::RecvError;
 
+use super::alert_bus::{now_secs, Signal, SignalKind};
 use super::market_data::{L2Event, L2Payload, Venue};
 use super::telegram_format::{
     format_alert_header, format_deep_link, format_metadata_row, html_escape, TelegramClient,
@@ -44,13 +46,23 @@ pub fn spawn(state: Arc<AppState>) {
         return;
     }
 
-    let Ok(bot_token) = std::env::var("TELEGRAM_BOT_TOKEN") else {
-        warn!("TELEGRAM_ALERTS_ENABLED=true but TELEGRAM_BOT_TOKEN missing; not starting");
-        return;
-    };
-    let Ok(chat_id) = std::env::var("TELEGRAM_CHAT_ID") else {
-        warn!("TELEGRAM_ALERTS_ENABLED=true but TELEGRAM_CHAT_ID missing; not starting");
-        return;
+    let digest_enabled = std::env::var("DIGEST_ENABLED")
+        .ok()
+        .and_then(|v| v.parse::<bool>().ok())
+        .unwrap_or(false);
+
+    let direct_send_client = if digest_enabled {
+        None
+    } else {
+        let Ok(bot_token) = std::env::var("TELEGRAM_BOT_TOKEN") else {
+            warn!("TELEGRAM_ALERTS_ENABLED=true but TELEGRAM_BOT_TOKEN missing; not starting");
+            return;
+        };
+        let Ok(chat_id) = std::env::var("TELEGRAM_CHAT_ID") else {
+            warn!("TELEGRAM_ALERTS_ENABLED=true but TELEGRAM_CHAT_ID missing; not starting");
+            return;
+        };
+        Some(TelegramClient::new(bot_token, chat_id))
     };
 
     let threshold_pct = std::env::var("PROB_ALERT_THRESHOLD_PCT")
@@ -74,15 +86,15 @@ pub fn spawn(state: Arc<AppState>) {
         .max(HARD_MIN_PRICE);
 
     info!(
-        "Starting Telegram probability alerts (threshold={}%, cooldown={}s, min_liquidity=${}, min_price={}¢)",
+        "Starting Telegram probability alerts (threshold={}%, cooldown={}s, min_liquidity=${}, min_price={}¢, digest={})",
         threshold_pct,
         cooldown.as_secs(),
         min_liquidity_usd,
         (min_price * 100.0) as i32,
+        digest_enabled,
     );
 
     let mut rx = state.market_data.subscribe();
-    let tg = TelegramClient::new(bot_token, chat_id);
 
     tokio::spawn(async move {
         let mut last_price: HashMap<String, f64> = HashMap::new();
@@ -93,7 +105,7 @@ pub fn spawn(state: Arc<AppState>) {
                 Ok(ev) => {
                     handle_event(
                         &state,
-                        &tg,
+                        direct_send_client.as_ref(),
                         threshold_pct,
                         cooldown,
                         min_liquidity_usd,
@@ -126,7 +138,7 @@ struct MarketContext {
 
 async fn handle_event(
     state: &AppState,
-    tg: &TelegramClient,
+    tg: Option<&TelegramClient>,
     threshold_pct: f64,
     cooldown: Duration,
     min_liquidity_usd: f64,
@@ -178,16 +190,54 @@ async fn handle_event(
 
     last_alert.insert(key, Instant::now());
 
-    let text = format_alert(
-        ctx.as_ref(),
-        ev.venue,
-        &ev.market_key,
-        prev_price,
-        price,
-        delta_pct,
+    if let Some(tg) = tg {
+        let text = format_alert(
+            ctx.as_ref(),
+            ev.venue,
+            &ev.market_key,
+            prev_price,
+            price,
+            delta_pct,
+        );
+        if let Err(e) = tg.send(&text).await {
+            warn!("telegram send failed: {}", e);
+        }
+    } else {
+        let signal = build_signal(ctx.as_ref(), ev.venue, &ev.market_key, prev_price, price, delta_pct);
+        state.alert_bus.publish(signal).await;
+    }
+}
+
+fn build_signal(
+    ctx: Option<&MarketContext>,
+    venue: Venue,
+    market_key: &str,
+    prev: f64,
+    curr: f64,
+    delta_pct: f64,
+) -> Signal {
+    let arrow = if delta_pct > 0.0 { "↑" } else { "↓" };
+    let question_raw = ctx
+        .map(|c| c.question.clone())
+        .unwrap_or_else(|| format!("{}:{}", venue.as_str(), truncate(market_key, 12)));
+    let body = format!(
+        "{arrow} {:.1}¢ → {:.1}¢  ({:+.1}%)",
+        prev * 100.0,
+        curr * 100.0,
+        delta_pct
     );
-    if let Err(e) = tg.send(&text).await {
-        warn!("telegram send failed: {}", e);
+    Signal {
+        kind: SignalKind::ProbabilityShift,
+        venue: venue.as_str().to_string(),
+        market_key: market_key.to_string(),
+        slug: ctx.and_then(|c| c.slug.clone()),
+        question: question_raw,
+        liquidity_usd: ctx.and_then(|c| c.liquidity_usd),
+        volume_24h_usd: ctx.and_then(|c| c.volume_24h_usd),
+        category: ctx.and_then(|c| c.category.clone()),
+        move_size: delta_pct.abs(),
+        body,
+        timestamp_secs: now_secs(),
     }
 }
 

--- a/app/src/services/volume_spike_alert.rs
+++ b/app/src/services/volume_spike_alert.rs
@@ -21,6 +21,7 @@ use chrono::{DateTime, Utc};
 use log::{info, warn};
 use serde::Serialize;
 
+use super::alert_bus::{now_secs, Signal, SignalKind};
 use crate::AppState;
 
 const DEFAULT_MULTIPLIER: f64 = 5.0;
@@ -63,6 +64,7 @@ struct MarketSnapshot {
     question: String,
     slug: String,
     volume_usdc: f64,
+    liquidity_usdc: Option<f64>,
     captured_at: DateTime<Utc>,
 }
 
@@ -77,13 +79,20 @@ pub fn spawn(state: Arc<AppState>) {
         return;
     }
 
-    let Ok(bot_token) = std::env::var("TELEGRAM_BOT_TOKEN") else {
-        warn!("VOLUME_SPIKE_ALERTS_ENABLED=true but TELEGRAM_BOT_TOKEN missing; not starting");
-        return;
-    };
-    let Ok(chat_id) = std::env::var("TELEGRAM_CHAT_ID") else {
-        warn!("VOLUME_SPIKE_ALERTS_ENABLED=true but TELEGRAM_CHAT_ID missing; not starting");
-        return;
+    let digest_enabled = env_bool("DIGEST_ENABLED", false);
+
+    let direct_send_client = if digest_enabled {
+        None
+    } else {
+        let Ok(bot_token) = std::env::var("TELEGRAM_BOT_TOKEN") else {
+            warn!("VOLUME_SPIKE_ALERTS_ENABLED=true but TELEGRAM_BOT_TOKEN missing; not starting");
+            return;
+        };
+        let Ok(chat_id) = std::env::var("TELEGRAM_CHAT_ID") else {
+            warn!("VOLUME_SPIKE_ALERTS_ENABLED=true but TELEGRAM_CHAT_ID missing; not starting");
+            return;
+        };
+        Some(TelegramClient::new(bot_token, chat_id))
     };
 
     let multiplier = env_f64("VOLUME_SPIKE_MULTIPLIER", DEFAULT_MULTIPLIER);
@@ -95,14 +104,13 @@ pub fn spawn(state: Arc<AppState>) {
     let poll = Duration::from_secs(env_u64("VOLUME_SPIKE_POLL_SECS", DEFAULT_POLL_SECS));
 
     info!(
-        "Starting volume-spike alerts (multiplier={:.2}x, min=${:.0}, cooldown={}s, poll={}s)",
+        "Starting volume-spike alerts (multiplier={:.2}x, min=${:.0}, cooldown={}s, poll={}s, digest={})",
         multiplier,
         min_usd,
         cooldown.as_secs(),
-        poll.as_secs()
+        poll.as_secs(),
+        digest_enabled,
     );
-
-    let tg = TelegramClient::new(bot_token, chat_id);
 
     tokio::spawn(async move {
         let mut buffers: HashMap<String, VecDeque<(DateTime<Utc>, f64)>> = HashMap::new();
@@ -126,13 +134,18 @@ pub fn spawn(state: Arc<AppState>) {
             let mut candidates: Vec<(String, f64, f64, f64)> = Vec::new();
             // Meta rebuilt every tick from the current scan — drops rows for
             // markets that have gone inactive.
-            let mut meta: HashMap<String, (Venue, String, String)> = HashMap::new();
+            let mut meta: HashMap<String, (Venue, String, String, Option<f64>)> = HashMap::new();
 
             for snap in snapshots {
                 let key = snap.key.clone();
                 meta.insert(
                     key.clone(),
-                    (snap.venue, snap.question.clone(), snap.slug.clone()),
+                    (
+                        snap.venue,
+                        snap.question.clone(),
+                        snap.slug.clone(),
+                        snap.liquidity_usdc,
+                    ),
                 );
 
                 let buf = buffers.entry(key.clone()).or_default();
@@ -161,7 +174,7 @@ pub fn spawn(state: Arc<AppState>) {
                         continue;
                     }
                 }
-                let Some((venue, question, slug)) = meta.get(&key).cloned() else {
+                let Some((venue, question, slug, liquidity)) = meta.get(&key).cloned() else {
                     continue;
                 };
                 let vol_24h = buffers
@@ -169,10 +182,17 @@ pub fn spawn(state: Arc<AppState>) {
                     .and_then(|b| b.back())
                     .map(|(_, v)| *v)
                     .unwrap_or(0.0);
-                let text = format_alert(venue, &question, &slug, rate_5m, rate_1h, vol_24h);
-                if let Err(e) = tg.send(&text).await {
-                    warn!("telegram send failed (volume-spike): {}", e);
-                    continue;
+                if let Some(tg) = direct_send_client.as_ref() {
+                    let text = format_alert(venue, &question, &slug, rate_5m, rate_1h, vol_24h);
+                    if let Err(e) = tg.send(&text).await {
+                        warn!("telegram send failed (volume-spike): {}", e);
+                        continue;
+                    }
+                } else {
+                    let signal = build_signal(
+                        venue, &key, &question, &slug, rate_5m, rate_1h, vol_24h, liquidity,
+                    );
+                    state.alert_bus.publish(signal).await;
                 }
                 last_alert.insert(key, Instant::now());
                 sent += 1;
@@ -181,9 +201,45 @@ pub fn spawn(state: Arc<AppState>) {
     });
 }
 
+fn build_signal(
+    venue: Venue,
+    market_key: &str,
+    question: &str,
+    slug: &str,
+    rate_5m: f64,
+    rate_1h: f64,
+    vol_24h: f64,
+    liquidity_usdc: Option<f64>,
+) -> Signal {
+    let ratio = if rate_1h > 0.0 { rate_5m / rate_1h } else { 0.0 };
+    let body = format!(
+        "Rate: <b>${}/min</b> last 5m vs ${}/min 1h baseline (<b>{:.1}x</b>)",
+        format_money(rate_5m),
+        format_money(rate_1h),
+        ratio,
+    );
+    let bare_key = market_key
+        .strip_prefix(&format!("{}:", venue.as_str()))
+        .unwrap_or(market_key)
+        .to_string();
+    Signal {
+        kind: SignalKind::VolumeSpike,
+        venue: venue.as_str().to_string(),
+        market_key: bare_key,
+        slug: (!slug.is_empty()).then(|| slug.to_string()),
+        question: question.to_string(),
+        liquidity_usd: liquidity_usdc,
+        volume_24h_usd: Some(vol_24h),
+        category: None,
+        move_size: ratio,
+        body,
+        timestamp_secs: now_secs(),
+    }
+}
+
 fn retain_known(
     buffers: &mut HashMap<String, VecDeque<(DateTime<Utc>, f64)>>,
-    meta: &HashMap<String, (Venue, String, String)>,
+    meta: &HashMap<String, (Venue, String, String, Option<f64>)>,
 ) {
     buffers.retain(|k, _| meta.contains_key(k));
 }
@@ -194,17 +250,19 @@ async fn fetch_snapshots(state: &AppState) -> Result<Vec<MarketSnapshot>, String
 
     let mut out = Vec::new();
 
-    let pm_rows: Vec<(String, String, Option<String>, Option<f64>)> = sqlx::query_as(
-        "SELECT condition_id, question, slug, \
-                volume_usdc::double precision \
-         FROM polymarket_scanned_markets \
-         WHERE active = TRUE",
-    )
-    .fetch_all(pool)
-    .await
-    .map_err(|e| format!("poly query: {}", e))?;
+    let pm_rows: Vec<(String, String, Option<String>, Option<f64>, Option<f64>)> =
+        sqlx::query_as(
+            "SELECT condition_id, question, slug, \
+                    volume_usdc::double precision, \
+                    liquidity_usdc::double precision \
+             FROM polymarket_scanned_markets \
+             WHERE active = TRUE",
+        )
+        .fetch_all(pool)
+        .await
+        .map_err(|e| format!("poly query: {}", e))?;
 
-    for (condition_id, question, slug, volume) in pm_rows {
+    for (condition_id, question, slug, volume, liquidity) in pm_rows {
         let Some(v) = volume else { continue };
         out.push(MarketSnapshot {
             venue: Venue::Polymarket,
@@ -212,12 +270,13 @@ async fn fetch_snapshots(state: &AppState) -> Result<Vec<MarketSnapshot>, String
             question,
             slug: slug.unwrap_or_default(),
             volume_usdc: v,
+            liquidity_usdc: liquidity,
             captured_at: now,
         });
     }
 
-    let lim_rows: Vec<(String, String, Option<f64>)> = sqlx::query_as(
-        "SELECT slug, question, volume_usdc \
+    let lim_rows: Vec<(String, String, Option<f64>, Option<f64>)> = sqlx::query_as(
+        "SELECT slug, question, volume_usdc, liquidity_usdc \
          FROM limitless_scanned_markets \
          WHERE active = TRUE",
     )
@@ -225,7 +284,7 @@ async fn fetch_snapshots(state: &AppState) -> Result<Vec<MarketSnapshot>, String
     .await
     .map_err(|e| format!("limitless query: {}", e))?;
 
-    for (slug, question, volume) in lim_rows {
+    for (slug, question, volume, liquidity) in lim_rows {
         let Some(v) = volume else { continue };
         out.push(MarketSnapshot {
             venue: Venue::Limitless,
@@ -233,6 +292,7 @@ async fn fetch_snapshots(state: &AppState) -> Result<Vec<MarketSnapshot>, String
             question,
             slug,
             volume_usdc: v,
+            liquidity_usdc: liquidity,
             captured_at: now,
         });
     }

--- a/app/tests/common/mod.rs
+++ b/app/tests/common/mod.rs
@@ -39,6 +39,7 @@ pub async fn build_test_state() -> Arc<AppState> {
     let ws_hub = WebSocketHub::new();
     let event_bus = EventBus::new();
     let market_data = Arc::new(relay44_backend::services::market_data::MarketDataBus::new());
+    let alert_bus = relay44_backend::services::alert_bus::AlertBus::new();
     let kyc = relay44_backend::services::kyc::KycService::new(
         relay44_backend::services::kyc::KycConfig::from_env(),
     );
@@ -55,6 +56,7 @@ pub async fn build_test_state() -> Arc<AppState> {
         ws_hub,
         event_bus,
         market_data,
+        alert_bus,
         kyc,
         limitless_partner: None,
         is_shutting_down: Arc::new(AtomicBool::new(false)),


### PR DESCRIPTION
## Summary
- Introduces `AlertBus`, an in-memory queue that `probability_alert` and `volume_spike_alert` publish signals to (when `DIGEST_ENABLED=true`) instead of sending to Telegram directly.
- Adds `digest_scheduler`: drains the bus on a fixed tick (default 60 min), scores by `sqrt(liquidity) * |move_size| * recency_decay`, dedupes by market, enforces a per-market cross-tick cooldown (default 4 h), and emits one ranked message with the top N (default 3) signals.
- Adds a per-hour rate cap to `new_market_alert`'s real-time path (default 3/hr) so a cluster of launches cannot flood the channel.
- `DIGEST_ENABLED=false` by default — the direct-send paths stay live until the flag is flipped, so this ships dark.

## Why
Before this, on a busy day the supergroup received 30+ alerts an hour and the few genuinely interesting moves were buried. Batching + scoring turns that into a single curated message per hour.

## Env vars
- `DIGEST_ENABLED` (default `false`)
- `DIGEST_INTERVAL_SECS` (default `3600`)
- `DIGEST_TOP_N` (default `3`)
- `DIGEST_MARKET_COOLDOWN_SECS` (default `14400`)
- `NEW_MARKET_RATE_LIMIT_PER_HOUR` (default `3`)

## Test plan
- [x] rustfmt clean
- [ ] `cargo test` (CI)
- [ ] verify dark ship on render (digest flag stays off)
- [ ] flip `DIGEST_ENABLED=true` and observe one aggregated message per hour in the supergroup