### PR TITLE
telegram: /quiet /subscribe /digest per-chat controls

### DIFF
--- a/app/src/services/digest_scheduler.rs
+++ b/app/src/services/digest_scheduler.rs
@@ -53,6 +53,7 @@ pub fn spawn(state: Arc<AppState>) {
     let interval_secs = env_u64("DIGEST_INTERVAL_SECS", DEFAULT_INTERVAL_SECS).max(60);
     let top_n = env_usize("DIGEST_TOP_N", DEFAULT_TOP_N).max(1);
     let cooldown_secs = env_u64("DIGEST_MARKET_COOLDOWN_SECS", DEFAULT_MARKET_COOLDOWN_SECS);
+    let parsed_chat_id: Option<i64> = chat_id.parse().ok();
 
     info!(
         "Starting digest scheduler (interval={}s, top_n={}, market_cooldown={}s)",
@@ -70,7 +71,15 @@ pub fn spawn(state: Arc<AppState>) {
 
         loop {
             interval.tick().await;
-            run_tick(&state, &tg, top_n, cooldown_secs, &mut last_alerted).await;
+            run_tick(
+                &state,
+                &tg,
+                top_n,
+                cooldown_secs,
+                parsed_chat_id,
+                &mut last_alerted,
+            )
+            .await;
         }
     });
 }
@@ -80,16 +89,48 @@ async fn run_tick(
     tg: &TelegramClient,
     top_n: usize,
     cooldown_secs: u64,
+    chat_id: Option<i64>,
     last_alerted: &mut HashMap<String, u64>,
 ) {
+    // Per-chat quiet window: if the destination chat is snoozed, drop
+    // the whole tick. Draining would lose signals the chat asked to defer.
+    if let Some(cid) = chat_id {
+        if crate::services::tg_chat_config::is_quiet_now(state.db.pool(), cid).await {
+            info!("digest tick: chat {} is in quiet window, skipping", cid);
+            return;
+        }
+    }
+
     let drained = state.alert_bus.drain().await;
     if drained.is_empty() {
         info!("digest tick: bus empty, skipping send");
         return;
     }
 
+    // Honor subscribed_kinds for the destination chat. An empty/absent list
+    // means "all kinds", so existing rows keep today's behavior.
+    let filtered: Vec<Signal> = if let Some(cid) = chat_id {
+        let pool = state.db.pool();
+        let mut kept = Vec::with_capacity(drained.len());
+        for s in drained {
+            if crate::services::tg_chat_config::is_kind_subscribed(pool, cid, s.kind.as_str())
+                .await
+            {
+                kept.push(s);
+            }
+        }
+        kept
+    } else {
+        drained
+    };
+
+    if filtered.is_empty() {
+        info!("digest tick: all signals filtered by subscribed_kinds, skipping send");
+        return;
+    }
+
     let now = now_secs();
-    let selected = select_top_signals(drained, top_n, cooldown_secs, now, last_alerted);
+    let selected = select_top_signals(filtered, top_n, cooldown_secs, now, last_alerted);
     if selected.is_empty() {
         info!("digest tick: all candidates filtered by cooldown, skipping send");
         return;
@@ -147,7 +188,7 @@ fn score(signal: &Signal, now: u64) -> f64 {
     liq_weight * signal.move_size.abs() * recency
 }
 
-fn format_digest(signals: &[Signal]) -> String {
+pub fn format_digest(signals: &[Signal]) -> String {
     let mut out = String::new();
     out.push_str("<b>\u{1F4CA} Top signals</b>\n");
     for (i, s) in signals.iter().enumerate() {

--- a/app/src/services/telegram_commands.rs
+++ b/app/src/services/telegram_commands.rs
@@ -163,6 +163,11 @@ async fn handle_message(
         "unmute" => unmute_text(state, msg.chat.id, parsed.args.as_deref()).await,
         "threshold" => threshold_text(state, msg.chat.id, parsed.args.as_deref()).await,
         "cooldown" => cooldown_text(state, msg.chat.id, parsed.args.as_deref()).await,
+        "quiet" => quiet_text(state, msg.chat.id, parsed.args.as_deref()).await,
+        "unquiet" => unquiet_text(state, msg.chat.id).await,
+        "subscribe" => subscribe_text(state, msg.chat.id, parsed.args.as_deref()).await,
+        "unsubscribe" => unsubscribe_text(state, msg.chat.id, parsed.args.as_deref()).await,
+        "digest" => digest_text(state).await,
         "config" => config_text(state, msg.chat.id).await,
         "link" => link_text(msg.chat.id, nonces, parsed.args.as_deref()),
         "verify" => verify_text(state, msg.chat.id, nonces, parsed.args.as_deref()).await,
@@ -206,6 +211,11 @@ fn help_text() -> String {
         "/unmute &lt;slug_or_id&gt; — undo a mute",
         "/threshold &lt;pct&gt; — per-chat alert threshold (e.g. 3 or 3.5%)",
         "/cooldown &lt;secs&gt; — per-chat alert cooldown (60-3600)",
+        "/quiet &lt;hours&gt; — snooze digest for this chat (0.25-168)",
+        "/unquiet — cancel an active quiet window",
+        "/subscribe &lt;kind&gt; — subscribe to a signal kind (probability_shift, volume_spike)",
+        "/unsubscribe &lt;kind&gt; — remove a signal kind",
+        "/digest — on-demand: drain bus and send current top signals",
         "/link &lt;0x…&gt; — start read-only wallet binding",
         "/verify &lt;signature&gt; — finish wallet binding",
         "/unlink — drop linked wallet",
@@ -397,6 +407,112 @@ async fn cooldown_text(state: &AppState, chat_id: i64, args: Option<&str>) -> St
             "query failed".to_string()
         }
     }
+}
+
+async fn quiet_text(state: &AppState, chat_id: i64, args: Option<&str>) -> String {
+    let raw = match args.and_then(|s| s.split_whitespace().next()) {
+        Some(s) => s.to_string(),
+        None => return "usage: /quiet &lt;hours&gt; (0.25-168)".to_string(),
+    };
+    let hours = match tg_chat_config::parse_quiet_hours_arg(&raw) {
+        Ok(v) => v,
+        Err(e) => return html_escape(&e),
+    };
+    match tg_chat_config::set_quiet_until(state.db.pool(), chat_id, hours).await {
+        Ok(until) => format!(
+            "quiet until {}",
+            html_escape(&until.format("%Y-%m-%d %H:%M UTC").to_string())
+        ),
+        Err(e) => {
+            warn!("/quiet persist failed: {}", e);
+            "query failed".to_string()
+        }
+    }
+}
+
+async fn unquiet_text(state: &AppState, chat_id: i64) -> String {
+    match tg_chat_config::clear_quiet_until(state.db.pool(), chat_id).await {
+        Ok(()) => "quiet window cleared".to_string(),
+        Err(e) => {
+            warn!("/unquiet persist failed: {}", e);
+            "query failed".to_string()
+        }
+    }
+}
+
+async fn subscribe_text(state: &AppState, chat_id: i64, args: Option<&str>) -> String {
+    let raw = match args.and_then(|s| s.split_whitespace().next()) {
+        Some(s) => s.to_string(),
+        None => {
+            return format!(
+                "usage: /subscribe &lt;kind&gt; ({})",
+                tg_chat_config::VALID_KINDS.join(", ")
+            );
+        }
+    };
+    let kind = match tg_chat_config::parse_kind_arg(&raw) {
+        Ok(k) => k,
+        Err(e) => return html_escape(&e),
+    };
+    match tg_chat_config::add_subscribed_kind(state.db.pool(), chat_id, kind).await {
+        Ok(()) => format!("subscribed to <code>{}</code>", kind),
+        Err(e) => {
+            warn!("/subscribe persist failed: {}", e);
+            "query failed".to_string()
+        }
+    }
+}
+
+async fn unsubscribe_text(state: &AppState, chat_id: i64, args: Option<&str>) -> String {
+    let raw = match args.and_then(|s| s.split_whitespace().next()) {
+        Some(s) => s.to_string(),
+        None => {
+            return format!(
+                "usage: /unsubscribe &lt;kind&gt; ({})",
+                tg_chat_config::VALID_KINDS.join(", ")
+            );
+        }
+    };
+    let kind = match tg_chat_config::parse_kind_arg(&raw) {
+        Ok(k) => k,
+        Err(e) => return html_escape(&e),
+    };
+    match tg_chat_config::remove_subscribed_kind(state.db.pool(), chat_id, kind).await {
+        Ok(()) => format!("unsubscribed from <code>{}</code>", kind),
+        Err(e) => {
+            warn!("/unsubscribe persist failed: {}", e);
+            "query failed".to_string()
+        }
+    }
+}
+
+/// Drains the alert bus immediately and returns a formatted digest. Bypasses
+/// the scheduler's cooldown and send path — the reply lands in the /digest
+/// caller's chat as a normal command response. Useful to peek at what would
+/// be sent on the next scheduled tick without waiting.
+async fn digest_text(state: &AppState) -> String {
+    use crate::services::digest_scheduler;
+    let drained = state.alert_bus.drain().await;
+    if drained.is_empty() {
+        return "bus empty — nothing queued".to_string();
+    }
+    let now = crate::services::alert_bus::now_secs();
+    let top_n = std::env::var("DIGEST_TOP_N")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(3)
+        .max(1);
+    let selected = digest_scheduler::select_top_signals(
+        drained,
+        top_n,
+        0,
+        now,
+        &std::collections::HashMap::new(),
+    );
+    if selected.is_empty() {
+        return "no signals after dedup".to_string();
+    }
+    digest_scheduler::format_digest(&selected)
 }
 
 async fn config_text(state: &AppState, chat_id: i64) -> String {

--- a/app/src/services/tg_chat_config.rs
+++ b/app/src/services/tg_chat_config.rs
@@ -24,6 +24,12 @@ const MIN_THRESHOLD_PCT: f32 = 0.1;
 const MAX_THRESHOLD_PCT: f32 = 50.0;
 const MIN_COOLDOWN_SECS: i32 = 60;
 const MAX_COOLDOWN_SECS: i32 = 3600;
+const MIN_QUIET_HOURS: f32 = 0.25;
+const MAX_QUIET_HOURS: f32 = 168.0;
+
+/// Signal kinds a chat may subscribe to. Strings match
+/// `SignalKind::as_str()` in `alert_bus.rs`.
+pub const VALID_KINDS: &[&str] = &["probability_shift", "volume_spike"];
 
 /// In-memory snapshot of a `tg_chat_config` row.
 #[derive(Debug, Clone, sqlx::FromRow)]
@@ -36,13 +42,16 @@ pub struct TgChatConfig {
     pub linked_user_id: Option<Uuid>,
     pub linked_wallet: Option<String>,
     pub linked_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub quiet_until: Option<chrono::DateTime<chrono::Utc>>,
+    pub subscribed_kinds: JsonValue,
 }
 
 /// Fetch the config row for `chat_id`, if any.
 pub async fn fetch(pool: &PgPool, chat_id: i64) -> Result<Option<TgChatConfig>, sqlx::Error> {
     sqlx::query_as::<_, TgChatConfig>(
         "SELECT chat_id, threshold_override, cooldown_override, muted_markets, \
-                allow_categories, linked_user_id, linked_wallet, linked_at \
+                allow_categories, linked_user_id, linked_wallet, linked_at, \
+                quiet_until, subscribed_kinds \
          FROM tg_chat_config WHERE chat_id = $1",
     )
     .bind(chat_id)
@@ -170,6 +179,168 @@ pub async fn set_linked_wallet(
     .map(|_| ())
 }
 
+/// Set `quiet_until = NOW() + hours`. Clamped to [0.25, 168] hours.
+pub async fn set_quiet_until(
+    pool: &PgPool,
+    chat_id: i64,
+    hours: f32,
+) -> Result<chrono::DateTime<chrono::Utc>, sqlx::Error> {
+    let clamped = hours.clamp(MIN_QUIET_HOURS, MAX_QUIET_HOURS);
+    let secs = (clamped as f64 * 3600.0) as i64;
+    let until = chrono::Utc::now() + chrono::Duration::seconds(secs);
+    sqlx::query(
+        "INSERT INTO tg_chat_config (chat_id, quiet_until, updated_at) \
+         VALUES ($1, $2, NOW()) \
+         ON CONFLICT (chat_id) DO UPDATE \
+           SET quiet_until = EXCLUDED.quiet_until, updated_at = NOW()",
+    )
+    .bind(chat_id)
+    .bind(until)
+    .execute(pool)
+    .await?;
+    Ok(until)
+}
+
+/// Clear `quiet_until` for `chat_id`. No-op if none was set.
+pub async fn clear_quiet_until(pool: &PgPool, chat_id: i64) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "UPDATE tg_chat_config SET quiet_until = NULL, updated_at = NOW() \
+         WHERE chat_id = $1",
+    )
+    .bind(chat_id)
+    .execute(pool)
+    .await
+    .map(|_| ())
+}
+
+/// Report whether `chat_id` is currently in a quiet window.
+pub async fn is_quiet_now(pool: &PgPool, chat_id: i64) -> bool {
+    let row: Result<Option<(Option<chrono::DateTime<chrono::Utc>>,)>, sqlx::Error> =
+        sqlx::query_as("SELECT quiet_until FROM tg_chat_config WHERE chat_id = $1")
+            .bind(chat_id)
+            .fetch_optional(pool)
+            .await;
+    matches!(row, Ok(Some((Some(until),))) if until > chrono::Utc::now())
+}
+
+/// Append `kind` to `subscribed_kinds`. No-op if already present.
+pub async fn add_subscribed_kind(
+    pool: &PgPool,
+    chat_id: i64,
+    kind: &str,
+) -> Result<(), sqlx::Error> {
+    let mut tx = pool.begin().await?;
+    let current: Option<JsonValue> = sqlx::query_scalar(
+        "SELECT subscribed_kinds FROM tg_chat_config WHERE chat_id = $1 FOR UPDATE",
+    )
+    .bind(chat_id)
+    .fetch_optional(&mut *tx)
+    .await?;
+
+    let next = add_to_json_array(current.as_ref(), kind);
+    sqlx::query(
+        "INSERT INTO tg_chat_config (chat_id, subscribed_kinds, updated_at) \
+         VALUES ($1, $2, NOW()) \
+         ON CONFLICT (chat_id) DO UPDATE \
+           SET subscribed_kinds = EXCLUDED.subscribed_kinds, updated_at = NOW()",
+    )
+    .bind(chat_id)
+    .bind(&next)
+    .execute(&mut *tx)
+    .await?;
+    tx.commit().await
+}
+
+/// Remove `kind` from `subscribed_kinds`. No-op if absent.
+pub async fn remove_subscribed_kind(
+    pool: &PgPool,
+    chat_id: i64,
+    kind: &str,
+) -> Result<(), sqlx::Error> {
+    let mut tx = pool.begin().await?;
+    let current: Option<JsonValue> = sqlx::query_scalar(
+        "SELECT subscribed_kinds FROM tg_chat_config WHERE chat_id = $1 FOR UPDATE",
+    )
+    .bind(chat_id)
+    .fetch_optional(&mut *tx)
+    .await?;
+
+    let next = remove_from_json_array(current.as_ref(), kind);
+    sqlx::query(
+        "INSERT INTO tg_chat_config (chat_id, subscribed_kinds, updated_at) \
+         VALUES ($1, $2, NOW()) \
+         ON CONFLICT (chat_id) DO UPDATE \
+           SET subscribed_kinds = EXCLUDED.subscribed_kinds, updated_at = NOW()",
+    )
+    .bind(chat_id)
+    .bind(&next)
+    .execute(&mut *tx)
+    .await?;
+    tx.commit().await
+}
+
+/// Report whether the chat is subscribed to `kind`. An empty or NULL
+/// `subscribed_kinds` list is treated as "all kinds" — so a fresh chat
+/// keeps receiving everything without explicit /subscribe calls.
+pub async fn is_kind_subscribed(pool: &PgPool, chat_id: i64, kind: &str) -> bool {
+    let row: Result<Option<(JsonValue,)>, sqlx::Error> = sqlx::query_as(
+        "SELECT subscribed_kinds FROM tg_chat_config WHERE chat_id = $1",
+    )
+    .bind(chat_id)
+    .fetch_optional(pool)
+    .await;
+    match row {
+        Ok(Some((val,))) => kind_is_subscribed(&val, kind),
+        _ => true,
+    }
+}
+
+/// Pure form of [`is_kind_subscribed`] for unit-testability.
+pub fn kind_is_subscribed(subscribed: &JsonValue, kind: &str) -> bool {
+    match subscribed {
+        JsonValue::Array(a) if a.is_empty() => true,
+        JsonValue::Array(_) => json_array_contains(subscribed, kind),
+        _ => true,
+    }
+}
+
+/// Normalize a /subscribe or /unsubscribe arg to a valid SignalKind
+/// string. Accepts the kind as-is or common aliases.
+pub fn parse_kind_arg(raw: &str) -> Result<&'static str, String> {
+    let lower = raw.trim().to_ascii_lowercase();
+    let normalized = match lower.as_str() {
+        "probability_shift" | "probability" | "prob" | "shift" => "probability_shift",
+        "volume_spike" | "volume" | "spike" => "volume_spike",
+        _ => {
+            return Err(format!(
+                "unknown kind '{}'. valid: {}",
+                raw,
+                VALID_KINDS.join(", ")
+            ));
+        }
+    };
+    Ok(normalized)
+}
+
+/// Parse the `<hours>` arg for `/quiet`. Accepts "2", "2h", "0.5".
+pub fn parse_quiet_hours_arg(raw: &str) -> Result<f32, String> {
+    let trimmed = raw.trim();
+    let numeric = trimmed.strip_suffix('h').unwrap_or(trimmed).trim();
+    let v: f32 = numeric
+        .parse()
+        .map_err(|_| format!("'{}' is not a number", trimmed))?;
+    if !v.is_finite() {
+        return Err("hours must be finite".to_string());
+    }
+    if v < MIN_QUIET_HOURS || v > MAX_QUIET_HOURS {
+        return Err(format!(
+            "quiet hours must be between {} and {}",
+            MIN_QUIET_HOURS, MAX_QUIET_HOURS
+        ));
+    }
+    Ok(v)
+}
+
 /// Clear any linked wallet for `chat_id`. No-op if none was set.
 pub async fn clear_linked_wallet(pool: &PgPool, chat_id: i64) -> Result<(), sqlx::Error> {
     sqlx::query(
@@ -217,7 +388,7 @@ pub async fn is_market_muted(pool: &PgPool, chat_id: i64, market: &str) -> bool 
 
 /// Human-readable dump for `/config`. Caller HTML-escapes as needed.
 pub fn dump_config_lines(cfg: Option<&TgChatConfig>) -> Vec<String> {
-    let (threshold, cooldown, muted, cats, wallet) = match cfg {
+    let (threshold, cooldown, muted, cats, wallet, quiet, subs) = match cfg {
         Some(c) => (
             c.threshold_override
                 .map(|v| format!("{:.2}%", v))
@@ -231,6 +402,21 @@ pub fn dump_config_lines(cfg: Option<&TgChatConfig>) -> Vec<String> {
                 .as_deref()
                 .map(shorten_wallet)
                 .unwrap_or_else(|| "—".to_string()),
+            match c.quiet_until {
+                Some(until) if until > chrono::Utc::now() => {
+                    until.format("until %Y-%m-%d %H:%M UTC").to_string()
+                }
+                _ => "off".to_string(),
+            },
+            match &c.subscribed_kinds {
+                JsonValue::Array(a) if a.is_empty() => "all".to_string(),
+                JsonValue::Array(a) => a
+                    .iter()
+                    .filter_map(|v| v.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", "),
+                _ => "all".to_string(),
+            },
         ),
         None => (
             "env default".to_string(),
@@ -238,6 +424,8 @@ pub fn dump_config_lines(cfg: Option<&TgChatConfig>) -> Vec<String> {
             0,
             0,
             "—".to_string(),
+            "off".to_string(),
+            "all".to_string(),
         ),
     };
     vec![
@@ -246,6 +434,8 @@ pub fn dump_config_lines(cfg: Option<&TgChatConfig>) -> Vec<String> {
         format!("muted markets: {}", muted),
         format!("allow categories: {}", cats),
         format!("linked wallet: {}", wallet),
+        format!("quiet: {}", quiet),
+        format!("subscribed: {}", subs),
     ]
 }
 
@@ -580,5 +770,43 @@ mod tests {
         let lines = dump_config_lines(None);
         assert!(lines.iter().any(|l| l.contains("env default")));
         assert!(lines.iter().any(|l| l.contains("linked wallet: —")));
+        assert!(lines.iter().any(|l| l.contains("quiet: off")));
+        assert!(lines.iter().any(|l| l.contains("subscribed: all")));
+    }
+
+    #[test]
+    fn parse_quiet_hours_accepts_numbers_and_suffix() {
+        assert!((parse_quiet_hours_arg("2").unwrap() - 2.0).abs() < 1e-6);
+        assert!((parse_quiet_hours_arg("2h").unwrap() - 2.0).abs() < 1e-6);
+        assert!((parse_quiet_hours_arg("0.5").unwrap() - 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn parse_quiet_hours_rejects_out_of_range() {
+        assert!(parse_quiet_hours_arg("0").is_err());
+        assert!(parse_quiet_hours_arg("999").is_err());
+        assert!(parse_quiet_hours_arg("abc").is_err());
+    }
+
+    #[test]
+    fn parse_kind_accepts_canonical_and_aliases() {
+        assert_eq!(parse_kind_arg("probability_shift").unwrap(), "probability_shift");
+        assert_eq!(parse_kind_arg("prob").unwrap(), "probability_shift");
+        assert_eq!(parse_kind_arg("VOLUME").unwrap(), "volume_spike");
+        assert_eq!(parse_kind_arg("volume_spike").unwrap(), "volume_spike");
+        assert!(parse_kind_arg("garbage").is_err());
+    }
+
+    #[test]
+    fn empty_subscribed_kinds_means_all() {
+        assert!(kind_is_subscribed(&json!([]), "probability_shift"));
+        assert!(kind_is_subscribed(&json!([]), "volume_spike"));
+    }
+
+    #[test]
+    fn non_empty_subscribed_kinds_is_exact_match() {
+        let subs = json!(["volume_spike"]);
+        assert!(kind_is_subscribed(&subs, "volume_spike"));
+        assert!(!kind_is_subscribed(&subs, "probability_shift"));
     }
 }

--- a/migrations/057_tg_chat_subscriptions.sql
+++ b/migrations/057_tg_chat_subscriptions.sql
@@ -1,0 +1,13 @@
+-- Per-chat subscription controls layered on top of tg_chat_config.
+--
+-- `quiet_until` lets a chat snooze digest delivery until a timestamp
+-- (NULL = not quiet). The digest_scheduler checks this before sending
+-- and silently skips while the window is active.
+--
+-- `subscribed_kinds` is a JSONB array of SignalKind strings (e.g.
+-- "probability_shift", "volume_spike"). Empty array means "all kinds"
+-- so existing chats continue to receive everything without backfill.
+
+ALTER TABLE tg_chat_config
+    ADD COLUMN IF NOT EXISTS quiet_until      TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS subscribed_kinds JSONB NOT NULL DEFAULT '[]'::jsonb;


### PR DESCRIPTION
## Summary
- Adds migration 057: `quiet_until TIMESTAMPTZ` + `subscribed_kinds JSONB` on `tg_chat_config`
- New Telegram commands: `/quiet <hours>`, `/unquiet`, `/subscribe <kind>`, `/unsubscribe <kind>`, `/digest`
- Digest scheduler honors the destination chat's `quiet_until` (skips tick) and `subscribed_kinds` (filters signals); empty list = all kinds, so existing rows keep today's behavior
- `/digest` drains the bus on demand and replies inline with the current top-N (useful for previewing what the next tick would send)

## Test plan
- [ ] Migration applies cleanly on staging (`057_tg_chat_subscriptions.sql`)
- [ ] `/subscribe volume_spike` → only volume spikes in next digest
- [ ] `/unsubscribe volume_spike` → digest returns to default
- [ ] `/quiet 1` → next scheduled tick logs "chat X is in quiet window, skipping"
- [ ] `/unquiet` → resumes delivery
- [ ] `/digest` → replies with current queue state (or "bus empty")
- [ ] `/config` shows new `quiet:` and `subscribed:` lines