### PR TITLE
web: fix by-slug market deep links doubling /v1 prefix

### DIFF
--- a/web/src/app/markets/by-slug/[provider]/[slug]/page.tsx
+++ b/web/src/app/markets/by-slug/[provider]/[slug]/page.tsx
@@ -21,7 +21,7 @@ export default function MarketBySlugPage() {
     (async () => {
       try {
         const url = resolveApiUrl(
-          `/v1/evm/markets/by-slug/${encodeURIComponent(provider)}/${encodeURIComponent(slug)}`,
+          `/evm/markets/by-slug/${encodeURIComponent(provider)}/${encodeURIComponent(slug)}`,
         );
         const res = await fetch(url, { cache: "no-store" });
         if (!res.ok) throw new Error(`resolve failed: ${res.status}`);


### PR DESCRIPTION
## Summary

- `resolveApiUrl` prefixes paths with `PRIMARY_API_BASE`, which in production is `/api/proxy`. The proxy already routes to a backend base ending in `/v1`, so callers must pass paths without the `/v1` prefix. The by-slug page was passing `/v1/evm/...`, producing `https://relay44-api.onrender.com/v1/v1/evm/markets/by-slug/...` → 404 → frontend renders "Market not found".
- Drops the leading `/v1` so the fetch resolves to `/api/proxy/evm/markets/by-slug/{provider}/{slug}` (matches every other `resolveApiUrl`/`this.request` caller in the codebase).

## Why it matters

Every Telegram alert deep link points at `https://relay44.com/markets/by-slug/{venue}/{slug}`. With the doubled prefix, every one of those links resolved to a broken page in prod.

## Test plan

- [ ] After deploy: open a Telegram digest link and confirm it redirects to the market detail page instead of rendering "Market not found".
- [ ] `curl -I https://relay44.com/api/proxy/evm/markets/by-slug/polymarket/2026-rbc-heritage-winner-scottie-scheffler-win` → 200.