### PR TITLE
bump sha2 0.10→0.11, hmac 0.12→0.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2435,7 +2435,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -2445,6 +2445,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -2880,7 +2889,7 @@ dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
  "getrandom 0.2.17",
- "hmac",
+ "hmac 0.12.1",
  "js-sys",
  "p256",
  "p384",
@@ -4099,7 +4108,7 @@ dependencies = [
  "env_logger",
  "futures",
  "hex",
- "hmac",
+ "hmac 0.13.0",
  "http 1.4.0",
  "jsonwebtoken",
  "k256",
@@ -4116,7 +4125,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serial_test",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "sha3",
  "siwe",
  "sqlx",
@@ -4187,7 +4196,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -4612,6 +4621,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -5744,7 +5764,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc905b200a95f2ea9146e43f2a7181e3aeb55de6bc12afb36462d00a3c7310de"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "pbkdf2",
  "sha2 0.10.9",
 ]
@@ -6511,7 +6531,7 @@ dependencies = [
  "generic-array",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "itoa",
  "log",
  "md-5",
@@ -6551,7 +6571,7 @@ dependencies = [
  "futures-util",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "home",
  "itoa",
  "log",

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -57,9 +57,9 @@ lazy_static = "1.4"
 rand = "0.10"
 
 # Cryptography
-sha2 = "0.10"
+sha2 = "0.11"
 sha3 = "0.10"
-hmac = "0.12"
+hmac = "0.13"
 hex = "0.4"
 aes-gcm = "0.10"
 k256 = { version = "0.13", features = ["ecdsa"] }

--- a/app/src/api/external.rs
+++ b/app/src/api/external.rs
@@ -2,7 +2,7 @@ use actix_web::{web, HttpRequest, HttpResponse, Responder};
 use base64::engine::general_purpose::URL_SAFE;
 use base64::Engine as _;
 use chrono::{DateTime, Duration, Utc};
-use hmac::{Hmac, Mac as _};
+use hmac::{Hmac, KeyInit as _, Mac as _};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use sha2::Sha256;

--- a/app/src/api/kyc.rs
+++ b/app/src/api/kyc.rs
@@ -81,7 +81,7 @@ pub async fn verify_kyc(
     let proof_hash = {
         let mut hasher = Sha256::new();
         hasher.update(body.proof.as_bytes());
-        format!("{:x}", hasher.finalize())
+        hex::encode(hasher.finalize())
     };
 
     // Record verification in DB (nullifier uniqueness enforced at DB level)

--- a/app/src/services/limitless_partner.rs
+++ b/app/src/services/limitless_partner.rs
@@ -4,7 +4,7 @@
 //! account_creation, delegated_signing) enabled by Limitless on our wallet.
 
 use chrono::Utc;
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use reqwest::header::{HeaderMap, HeaderValue};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};


### PR DESCRIPTION
## Summary

- Upgrade sha2 0.10 → 0.11 and hmac 0.12 → 0.13
- sha2 0.11: `Output` no longer implements `LowerHex` — switched to `hex::encode` in kyc.rs
- hmac 0.13: `new_from_slice` moved to `KeyInit` trait — added import in external.rs and limitless_partner.rs
- Supersedes dependabot PRs #113 and #114 (which failed CI due to these API changes)

## Test plan

- [x] `cargo check` + `cargo clippy` pass
- [ ] CI passes
- [ ] Verify HMAC signing still works (Polymarket + Limitless partner API)