### PR TITLE
Ship $RELAY utility surface: endpoint, SDK exports, agent x402 helpers, dashboard, docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Format: keep unreleased changes under `Unreleased`. Move entries to a dated sect
 - Public Tokenomics page at `/tokenomics` covering fee flow, staking tiers, reward allocation, and roadmap
 - `GET /api/contracts/[name]/abi` endpoint serving MarketCore, OrderBook, RelayStaking, and ERC20 ABIs as JSON for external integrators
 - `GET /v1/protocol/metrics` endpoint and `/protocol` dashboard for public protocol-level markets, agents, settlement volume, and collateral metrics
+- `GET /v1/protocol/relay-utility` endpoint exposing chain id, RELAY token state, staking total + tier table with fee-discount bps and x402 bypass flags, reward distributor address, and live utility flags
 - `@relay44/protocol` workspace package with generated ABIs, deployment manifest, typed addresses, and helper functions
 - `examples/protocol-read-market` TypeScript example that reads `MarketCore.marketCount` on Base mainnet
 - npm publish workflow for `@relay44/protocol` and `@relay44/agent-sdk`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Format: keep unreleased changes under `Unreleased`. Move entries to a dated sect
 - `GET /v1/protocol/metrics` endpoint and `/protocol` dashboard for public protocol-level markets, agents, settlement volume, and collateral metrics
 - `GET /v1/protocol/relay-utility` endpoint exposing chain id, RELAY token state, staking total + tier table with fee-discount bps and x402 bypass flags, reward distributor address, and live utility flags
 - `@relay44/protocol` workspace package with generated ABIs, deployment manifest, typed addresses, and helper functions
+- `@relay44/protocol` RELAY utility exports: `RELAY_TIERS` (Bronze/Silver/Gold/Diamond) with thresholds and fee-discount bps, `X402_BYPASS_TIER`, `RELAY_DECIMALS`, `relayTierFromStakedWei`, `relayTierById`, `getRelayUtilityAddresses`, `getRelayChainId`
 - `examples/protocol-read-market` TypeScript example that reads `MarketCore.marketCount` on Base mainnet
 - npm publish workflow for `@relay44/protocol` and `@relay44/agent-sdk`
 - `web/src/lib/protocol.ts` as single source of truth for docs-facing contract metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Format: keep unreleased changes under `Unreleased`. Move entries to a dated sect
 - `GET /v1/protocol/relay-utility` endpoint exposing chain id, RELAY token state, staking total + tier table with fee-discount bps and x402 bypass flags, reward distributor address, and live utility flags
 - `@relay44/protocol` workspace package with generated ABIs, deployment manifest, typed addresses, and helper functions
 - `@relay44/protocol` RELAY utility exports: `RELAY_TIERS` (Bronze/Silver/Gold/Diamond) with thresholds and fee-discount bps, `X402_BYPASS_TIER`, `RELAY_DECIMALS`, `relayTierFromStakedWei`, `relayTierById`, `getRelayUtilityAddresses`, `getRelayChainId`
+- `@relay44/agent-sdk` x402 helpers: `qualifyX402ByTier`, `qualifyX402FromStaked`, `qualifyX402OnChain`, and `priceForX402Tier` so agents can compute their own bypass/discount before calling paid endpoints
 - `examples/protocol-read-market` TypeScript example that reads `MarketCore.marketCount` on Base mainnet
 - npm publish workflow for `@relay44/protocol` and `@relay44/agent-sdk`
 - `web/src/lib/protocol.ts` as single source of truth for docs-facing contract metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Format: keep unreleased changes under `Unreleased`. Move entries to a dated sect
 - `@relay44/protocol` workspace package with generated ABIs, deployment manifest, typed addresses, and helper functions
 - `@relay44/protocol` RELAY utility exports: `RELAY_TIERS` (Bronze/Silver/Gold/Diamond) with thresholds and fee-discount bps, `X402_BYPASS_TIER`, `RELAY_DECIMALS`, `relayTierFromStakedWei`, `relayTierById`, `getRelayUtilityAddresses`, `getRelayChainId`
 - `@relay44/agent-sdk` x402 helpers: `qualifyX402ByTier`, `qualifyX402FromStaked`, `qualifyX402OnChain`, and `priceForX402Tier` so agents can compute their own bypass/discount before calling paid endpoints
+- `/docs/protocol/relay-utility` page documenting the public RELAY utility surface for humans and agents
+- Quickstart steps covering the new `/v1/protocol/relay-utility` endpoint and on-chain staking-tier checks via `@relay44/agent-sdk`
 - `examples/protocol-read-market` TypeScript example that reads `MarketCore.marketCount` on Base mainnet
 - npm publish workflow for `@relay44/protocol` and `@relay44/agent-sdk`
 - `web/src/lib/protocol.ts` as single source of truth for docs-facing contract metadata

--- a/app/src/api/protocol.rs
+++ b/app/src/api/protocol.rs
@@ -3,7 +3,11 @@ use chrono::Utc;
 use serde::Serialize;
 use std::sync::Arc;
 
+use crate::services::staking;
 use crate::{api::ApiError, AppState};
+
+const ERC20_TOTAL_SUPPLY_SELECTOR: &str = "0x18160ddd";
+const ERC20_DECIMALS_SELECTOR: &str = "0x313ce567";
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -143,4 +147,231 @@ pub async fn get_protocol_metrics(
         source: "relay44-api".to_string(),
         updated_at: Utc::now().to_rfc3339(),
     }))
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RelayUtilityResponse {
+    pub chain_id: u64,
+    pub token: TokenSummary,
+    pub staking: StakingSummary,
+    pub reward_distributor: RewardDistributorSummary,
+    pub flags: UtilityFlags,
+    pub source: String,
+    pub updated_at: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TokenSummary {
+    pub address: String,
+    pub total_supply_hex: String,
+    pub decimals: u8,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StakingSummary {
+    pub address: String,
+    pub total_staked_hex: String,
+    pub tiers: Vec<StakingTierSummary>,
+    pub x402_bypass_tier: u64,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StakingTierSummary {
+    pub tier: u64,
+    pub name: String,
+    pub min_relay_wei: String,
+    pub fee_discount_bps: u64,
+    pub x402_bypass: bool,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RewardDistributorSummary {
+    pub address: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UtilityFlags {
+    pub fee_discount: bool,
+    pub x402_discount: bool,
+    pub staking_rewards: bool,
+    pub agent_rewards: bool,
+    pub creator_rewards: bool,
+    pub governance: bool,
+}
+
+fn is_valid_evm_address(addr: &str) -> bool {
+    let trimmed = addr.trim();
+    trimmed.len() == 42
+        && trimmed.starts_with("0x")
+        && trimmed[2..].chars().all(|c| c.is_ascii_hexdigit())
+}
+
+fn parse_u8_hex(value: &str) -> Result<u8, ApiError> {
+    let trimmed = value.trim_start_matches("0x");
+    let normalized = trimmed.trim_start_matches('0');
+    if normalized.is_empty() {
+        return Ok(0);
+    }
+    u8::from_str_radix(normalized, 16)
+        .map_err(|_| ApiError::internal("Failed to parse hex value"))
+}
+
+pub async fn get_relay_utility(
+    state: web::Data<Arc<AppState>>,
+) -> Result<HttpResponse, ApiError> {
+    if !state.config.evm_enabled || !state.config.evm_reads_enabled {
+        return Err(ApiError::bad_request(
+            "EVM_DISABLED",
+            "EVM services are disabled",
+        ));
+    }
+
+    let token_address = state.config.relay_token_address.trim();
+    if token_address.is_empty() || !is_valid_evm_address(token_address) {
+        return Err(ApiError::bad_request(
+            "INVALID_TOKEN_ADDRESS",
+            "RELAY_TOKEN_ADDRESS must be configured as a valid 0x EVM address",
+        ));
+    }
+
+    let staking_address = state.config.relay_staking_address.trim();
+    if staking_address.is_empty() || !is_valid_evm_address(staking_address) {
+        return Err(ApiError::bad_request(
+            "INVALID_STAKING_ADDRESS",
+            "RELAY_STAKING_ADDRESS must be configured as a valid 0x EVM address",
+        ));
+    }
+
+    let reward_distributor_address = state.config.reward_distributor_address.trim();
+    if reward_distributor_address.is_empty() || !is_valid_evm_address(reward_distributor_address) {
+        return Err(ApiError::bad_request(
+            "INVALID_REWARD_DISTRIBUTOR_ADDRESS",
+            "REWARD_DISTRIBUTOR_ADDRESS must be configured as a valid 0x EVM address",
+        ));
+    }
+
+    let total_supply_hex = state
+        .evm_rpc
+        .eth_call(token_address, ERC20_TOTAL_SUPPLY_SELECTOR)
+        .await
+        .map_err(|err| {
+            log::error!("relay-utility: totalSupply call failed: {}", err);
+            ApiError::internal("Failed to read RELAY total supply")
+        })?;
+    let decimals_hex = state
+        .evm_rpc
+        .eth_call(token_address, ERC20_DECIMALS_SELECTOR)
+        .await
+        .map_err(|err| {
+            log::error!("relay-utility: decimals call failed: {}", err);
+            ApiError::internal("Failed to read RELAY decimals")
+        })?;
+    let decimals = parse_u8_hex(&decimals_hex)?;
+
+    let total_staked_hex = staking::get_total_staked_hex(&state.evm_rpc, staking_address)
+        .await
+        .map_err(|err| {
+            log::error!("relay-utility: totalStaked call failed: {}", err);
+            ApiError::internal("Failed to read RELAY totalStaked")
+        })?;
+
+    let tiers = staking::TIERS
+        .iter()
+        .map(|t| StakingTierSummary {
+            tier: t.tier,
+            name: t.name.to_string(),
+            min_relay_wei: t.min_relay_wei.to_string(),
+            fee_discount_bps: t.fee_discount_bps,
+            x402_bypass: t.x402_bypass,
+        })
+        .collect();
+
+    let response = RelayUtilityResponse {
+        chain_id: state.config.base_chain_id,
+        token: TokenSummary {
+            address: token_address.to_ascii_lowercase(),
+            total_supply_hex,
+            decimals,
+        },
+        staking: StakingSummary {
+            address: staking_address.to_ascii_lowercase(),
+            total_staked_hex,
+            tiers,
+            x402_bypass_tier: staking::X402_BYPASS_TIER,
+        },
+        reward_distributor: RewardDistributorSummary {
+            address: reward_distributor_address.to_ascii_lowercase(),
+        },
+        flags: UtilityFlags {
+            fee_discount: true,
+            x402_discount: state.config.x402_enabled,
+            staking_rewards: true,
+            agent_rewards: true,
+            creator_rewards: true,
+            governance: false,
+        },
+        source: "relay44-api".to_string(),
+        updated_at: Utc::now().to_rfc3339(),
+    };
+
+    Ok(HttpResponse::Ok().json(response))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_evm_addresses() {
+        assert!(is_valid_evm_address("0x580fF5Ae64eC792A949c6123386A8A936c7EBB07"));
+        assert!(is_valid_evm_address(
+            "0x0000000000000000000000000000000000000000"
+        ));
+        assert!(!is_valid_evm_address(""));
+        assert!(!is_valid_evm_address("0x"));
+        assert!(!is_valid_evm_address("0x123"));
+        assert!(!is_valid_evm_address(
+            "580fF5Ae64eC792A949c6123386A8A936c7EBB07"
+        )); // missing 0x
+        assert!(!is_valid_evm_address(
+            "0x580fF5Ae64eC792A949c6123386A8A936c7EBBZZ"
+        )); // non-hex
+    }
+
+    #[test]
+    fn parses_u8_hex_values() {
+        assert_eq!(parse_u8_hex("0x00").unwrap(), 0);
+        assert_eq!(
+            parse_u8_hex("0x0000000000000000000000000000000000000000000000000000000000000012")
+                .unwrap(),
+            18
+        );
+        assert_eq!(parse_u8_hex("0x12").unwrap(), 18);
+        assert_eq!(parse_u8_hex("0xff").unwrap(), 255);
+        assert!(parse_u8_hex("0xnotahex").is_err());
+    }
+
+    #[test]
+    fn utility_response_includes_all_four_tiers() {
+        let tiers: Vec<StakingTierSummary> = staking::TIERS
+            .iter()
+            .map(|t| StakingTierSummary {
+                tier: t.tier,
+                name: t.name.to_string(),
+                min_relay_wei: t.min_relay_wei.to_string(),
+                fee_discount_bps: t.fee_discount_bps,
+                x402_bypass: t.x402_bypass,
+            })
+            .collect();
+        assert_eq!(tiers.len(), 4);
+        assert_eq!(tiers[0].name, "Bronze");
+        assert_eq!(tiers[3].name, "Diamond");
+        assert_eq!(tiers[3].fee_discount_bps, 7_500);
+    }
 }

--- a/app/src/config/mod.rs
+++ b/app/src/config/mod.rs
@@ -100,6 +100,7 @@ pub struct AppConfig {
     pub erc8004_reputation_registry_address: String,
     pub erc8004_validation_registry_address: String,
     pub relay_staking_address: String,
+    pub reward_distributor_address: String,
     pub x402_enabled: bool,
     pub x402_signing_key: String,
     pub x402_receiver_address: String,
@@ -490,6 +491,8 @@ impl AppConfig {
             erc8004_validation_registry_address: env::var("ERC8004_VALIDATION_REGISTRY_ADDRESS")
                 .unwrap_or_else(|_| "".to_string()),
             relay_staking_address: env::var("RELAY_STAKING_ADDRESS")
+                .unwrap_or_else(|_| "".to_string()),
+            reward_distributor_address: env::var("REWARD_DISTRIBUTOR_ADDRESS")
                 .unwrap_or_else(|_| "".to_string()),
             x402_enabled,
             x402_signing_key,

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -231,10 +231,14 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
                             ),
                     ),
                 )
-                .service(web::scope("/protocol").route(
-                    "/metrics",
-                    web::get().to(api::protocol::get_protocol_metrics),
-                ))
+                .service(
+                    web::scope("/protocol")
+                        .route("/metrics", web::get().to(api::protocol::get_protocol_metrics))
+                        .route(
+                            "/relay-utility",
+                            web::get().to(api::protocol::get_relay_utility),
+                        ),
+                )
                 .service(
                     web::scope("/evm")
                         .configure(api::creator::configure)

--- a/app/src/services/staking.rs
+++ b/app/src/services/staking.rs
@@ -2,6 +2,65 @@ use crate::services::evm_rpc::EvmRpcService;
 
 // keccak256("getTier(address)")[:4] = 0xb45aae52
 const GET_TIER_SELECTOR: &str = "0xb45aae52";
+// keccak256("totalStaked()")[:4] = 0x817b1cd2
+const TOTAL_STAKED_SELECTOR: &str = "0x817b1cd2";
+
+pub const RELAY_DECIMALS: u8 = 18;
+pub const X402_BYPASS_TIER: u64 = 2;
+
+/// Tier metadata mirroring `evm/src/RelayStaking.sol::getTier` and
+/// `evm/src/OrderBook.sol::TIERn_THRESHOLD`. Order is significant: index = tier id.
+pub const TIERS: &[StakingTier] = &[
+    StakingTier {
+        tier: 0,
+        name: "Bronze",
+        min_relay_wei: "0",
+        fee_discount_bps: 0,
+        x402_bypass: false,
+    },
+    StakingTier {
+        tier: 1,
+        name: "Silver",
+        min_relay_wei: "1000000000000000000000",
+        fee_discount_bps: 2_500,
+        x402_bypass: false,
+    },
+    StakingTier {
+        tier: 2,
+        name: "Gold",
+        min_relay_wei: "10000000000000000000000",
+        fee_discount_bps: 5_000,
+        x402_bypass: true,
+    },
+    StakingTier {
+        tier: 3,
+        name: "Diamond",
+        min_relay_wei: "100000000000000000000000",
+        fee_discount_bps: 7_500,
+        x402_bypass: true,
+    },
+];
+
+#[derive(Debug, Clone, Copy)]
+pub struct StakingTier {
+    pub tier: u64,
+    pub name: &'static str,
+    pub min_relay_wei: &'static str,
+    pub fee_discount_bps: u64,
+    pub x402_bypass: bool,
+}
+
+pub async fn get_total_staked_hex(
+    rpc: &EvmRpcService,
+    staking_address: &str,
+) -> Result<String, String> {
+    if staking_address.is_empty() {
+        return Err("staking address not configured".to_string());
+    }
+    rpc.eth_call(staking_address, TOTAL_STAKED_SELECTOR)
+        .await
+        .map_err(|e| format!("totalStaked call failed: {e}"))
+}
 
 pub async fn get_staking_tier(
     rpc: &EvmRpcService,
@@ -56,4 +115,63 @@ pub fn discounted_amount(base_amount: u64, tier: u64) -> u64 {
         return base_amount;
     }
     base_amount - (base_amount * discount) / 10_000
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tier_metadata_matches_solidity_thresholds() {
+        // Mirror evm/src/OrderBook.sol TIER1/2/3_THRESHOLD constants.
+        assert_eq!(TIERS.len(), 4);
+        assert_eq!(TIERS[0].tier, 0);
+        assert_eq!(TIERS[0].min_relay_wei, "0");
+        assert_eq!(TIERS[0].fee_discount_bps, 0);
+        assert!(!TIERS[0].x402_bypass);
+
+        assert_eq!(TIERS[1].min_relay_wei, "1000000000000000000000"); // 1_000e18
+        assert_eq!(TIERS[1].fee_discount_bps, 2_500);
+        assert!(!TIERS[1].x402_bypass);
+
+        assert_eq!(TIERS[2].min_relay_wei, "10000000000000000000000"); // 10_000e18
+        assert_eq!(TIERS[2].fee_discount_bps, 5_000);
+        assert!(TIERS[2].x402_bypass);
+
+        assert_eq!(TIERS[3].min_relay_wei, "100000000000000000000000"); // 100_000e18
+        assert_eq!(TIERS[3].fee_discount_bps, 7_500);
+        assert!(TIERS[3].x402_bypass);
+    }
+
+    #[test]
+    fn tier_discount_bps_matches_orderbook() {
+        // Mirror evm/src/OrderBook.sol::getDiscountBps tier branches.
+        assert_eq!(tier_discount_bps(0), 0);
+        assert_eq!(tier_discount_bps(1), 2_500);
+        assert_eq!(tier_discount_bps(2), 5_000);
+        assert_eq!(tier_discount_bps(3), 7_500);
+        assert_eq!(tier_discount_bps(99), 7_500);
+    }
+
+    #[test]
+    fn discounted_amount_applies_tier_correctly() {
+        let base = 10_000_u64;
+        assert_eq!(discounted_amount(base, 0), 10_000);
+        assert_eq!(discounted_amount(base, 1), 7_500);
+        assert_eq!(discounted_amount(base, 2), 0);
+        assert_eq!(discounted_amount(base, 3), 0);
+        assert_eq!(discounted_amount(base, 99), 0);
+    }
+
+    #[test]
+    fn x402_bypass_threshold_matches_constant() {
+        for tier in &[0_u64, 1] {
+            assert!(*tier < X402_BYPASS_TIER);
+            assert!(!TIERS[*tier as usize].x402_bypass);
+        }
+        for tier in &[2_u64, 3] {
+            assert!(*tier >= X402_BYPASS_TIER);
+            assert!(TIERS[*tier as usize].x402_bypass);
+        }
+    }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -553,6 +553,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
       "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
@@ -1168,6 +1169,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1519,6 +1521,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2001,6 +2004,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -2160,6 +2164,7 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -2681,6 +2686,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2873,6 +2879,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/sdk/agent/package.json
+++ b/sdk/agent/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "test": "npm run check:protocol && npm run build",
+    "test": "npm run check:protocol && npm run build && node --test test/*.test.mjs",
     "check:protocol": "node ../protocol/scripts/generate.mjs --check",
     "check:abi": "npm run check:protocol",
     "lint": "eslint src --ext .ts"

--- a/sdk/agent/src/index.ts
+++ b/sdk/agent/src/index.ts
@@ -68,3 +68,21 @@ export {
   DEFAULT_CONTRACTS_BASE_URL,
 } from './abis';
 export type { ContractAbiName } from './abis';
+
+// x402 tier-qualification helpers (RELAY staking → x402 access).
+export {
+  RELAY_TIERS,
+  RELAY_DECIMALS,
+  X402_BYPASS_TIER,
+  qualifyX402ByTier,
+  qualifyX402FromStaked,
+  qualifyX402OnChain,
+  priceForX402Tier,
+} from './x402';
+export type {
+  RelayTier,
+  X402Qualification,
+  X402PriceBreakdown,
+  RelayStakingReader,
+  QualifyOnChainOptions,
+} from './x402';

--- a/sdk/agent/src/x402.ts
+++ b/sdk/agent/src/x402.ts
@@ -1,0 +1,123 @@
+// x402 tier-qualification helpers for agents calling Relay44 paid endpoints.
+//
+// The protocol charges a base x402 price per resource. Stakers get a discount
+// (or full bypass at tier >= X402_BYPASS_TIER). These helpers are read-only
+// and let an agent decide locally whether a wallet should attach a payment
+// signature, request a bypass, or expect a discounted quote — without
+// duplicating tier constants on the client.
+
+import {
+  RELAY_TIERS,
+  RELAY_DECIMALS,
+  X402_BYPASS_TIER,
+  relayTierById,
+  relayTierFromStakedWei,
+  type RelayTier,
+  type NetworkName,
+  getRelayUtilityAddresses,
+  RELAY_STAKING_ABI,
+} from '@relay44/protocol';
+
+export { RELAY_TIERS, RELAY_DECIMALS, X402_BYPASS_TIER, type RelayTier };
+
+export interface X402Qualification {
+  /** Resolved tier metadata. */
+  tier: RelayTier;
+  /** True iff the wallet bypasses x402 charges entirely. */
+  bypassesX402: boolean;
+  /**
+   * Discount applied to the base x402 price, in basis points (10_000 = 100%).
+   * Equal to 10_000 when the tier bypasses x402, otherwise the tier's
+   * underlying fee-discount bps.
+   */
+  x402DiscountBps: number;
+}
+
+function buildQualification(tier: RelayTier): X402Qualification {
+  return {
+    tier,
+    bypassesX402: tier.x402Bypass,
+    x402DiscountBps: tier.x402Bypass ? 10_000 : tier.feeDiscountBps,
+  };
+}
+
+/** Qualify x402 access from a known tier id (0..3). */
+export function qualifyX402ByTier(tier: number): X402Qualification {
+  return buildQualification(relayTierById(tier));
+}
+
+/** Qualify x402 access from a wallet's staked RELAY balance (in wei). */
+export function qualifyX402FromStaked(stakedWei: bigint): X402Qualification {
+  return buildQualification(relayTierFromStakedWei(stakedWei));
+}
+
+export interface X402PriceBreakdown {
+  /** Base price quoted by the resource, in micro-USDC (10^-6 USDC). */
+  baseMicroUsdc: bigint;
+  /** Effective price after applying the wallet's tier, in micro-USDC. */
+  effectiveMicroUsdc: bigint;
+  qualification: X402Qualification;
+}
+
+/**
+ * Compute the effective x402 price for a wallet's tier.
+ *
+ * Mirrors `app/src/services/staking::discounted_amount`: tier >= X402_BYPASS_TIER
+ * pays nothing, otherwise the tier's fee-discount bps are applied.
+ */
+export function priceForX402Tier(
+  baseMicroUsdc: bigint,
+  qualification: X402Qualification,
+): X402PriceBreakdown {
+  if (qualification.bypassesX402) {
+    return { baseMicroUsdc, effectiveMicroUsdc: 0n, qualification };
+  }
+  if (qualification.x402DiscountBps === 0) {
+    return { baseMicroUsdc, effectiveMicroUsdc: baseMicroUsdc, qualification };
+  }
+  const discount = (baseMicroUsdc * BigInt(qualification.x402DiscountBps)) / 10_000n;
+  return {
+    baseMicroUsdc,
+    effectiveMicroUsdc: baseMicroUsdc - discount,
+    qualification,
+  };
+}
+
+/**
+ * Minimal read-client contract — anything with an `eth_call` of `getTier(address)`
+ * works (e.g. a viem `PublicClient.readContract` or a hand-rolled JSON-RPC).
+ */
+export interface RelayStakingReader {
+  readContract: (args: {
+    address: `0x${string}`;
+    abi: typeof RELAY_STAKING_ABI;
+    functionName: 'getTier';
+    args: [`0x${string}`];
+  }) => Promise<bigint | number>;
+}
+
+export interface QualifyOnChainOptions {
+  client: RelayStakingReader;
+  network: NetworkName;
+  wallet: `0x${string}`;
+}
+
+/**
+ * Read the wallet's tier from the deployed RelayStaking contract on the given
+ * network and return its x402 qualification.
+ */
+export async function qualifyX402OnChain({
+  client,
+  network,
+  wallet,
+}: QualifyOnChainOptions): Promise<X402Qualification> {
+  const { staking } = getRelayUtilityAddresses(network);
+  const result = await client.readContract({
+    address: staking,
+    abi: RELAY_STAKING_ABI,
+    functionName: 'getTier',
+    args: [wallet],
+  });
+  const tierNum = typeof result === 'bigint' ? Number(result) : result;
+  return qualifyX402ByTier(tierNum);
+}

--- a/sdk/agent/test/x402.test.mjs
+++ b/sdk/agent/test/x402.test.mjs
@@ -1,0 +1,91 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const sdk = await import('../dist/index.js');
+
+test('qualifyX402ByTier resolves all four tiers', () => {
+  const t0 = sdk.qualifyX402ByTier(0);
+  assert.equal(t0.tier.tier, 0);
+  assert.equal(t0.bypassesX402, false);
+  assert.equal(t0.x402DiscountBps, 0);
+
+  const t1 = sdk.qualifyX402ByTier(1);
+  assert.equal(t1.tier.tier, 1);
+  assert.equal(t1.bypassesX402, false);
+  assert.equal(t1.x402DiscountBps, 2_500);
+
+  const t2 = sdk.qualifyX402ByTier(2);
+  assert.equal(t2.tier.tier, 2);
+  assert.equal(t2.bypassesX402, true);
+  assert.equal(t2.x402DiscountBps, 10_000);
+
+  const t3 = sdk.qualifyX402ByTier(3);
+  assert.equal(t3.tier.tier, 3);
+  assert.equal(t3.bypassesX402, true);
+  assert.equal(t3.x402DiscountBps, 10_000);
+});
+
+test('qualifyX402FromStaked snaps wallets at threshold boundaries', () => {
+  const wei = (n) => BigInt(n) * 10n ** 18n;
+  assert.equal(sdk.qualifyX402FromStaked(0n).tier.name, 'Bronze');
+  assert.equal(sdk.qualifyX402FromStaked(wei(999)).tier.name, 'Bronze');
+  assert.equal(sdk.qualifyX402FromStaked(wei(1_000)).tier.name, 'Silver');
+  assert.equal(sdk.qualifyX402FromStaked(wei(10_000)).tier.name, 'Gold');
+  assert.equal(sdk.qualifyX402FromStaked(wei(100_000)).tier.name, 'Diamond');
+});
+
+test('priceForX402Tier mirrors the Rust discounted_amount semantics', () => {
+  const base = 10_000n; // micro-USDC
+  const qBronze = sdk.qualifyX402ByTier(0);
+  const qSilver = sdk.qualifyX402ByTier(1);
+  const qGold = sdk.qualifyX402ByTier(2);
+  const qDiamond = sdk.qualifyX402ByTier(3);
+
+  assert.equal(sdk.priceForX402Tier(base, qBronze).effectiveMicroUsdc, 10_000n);
+  assert.equal(sdk.priceForX402Tier(base, qSilver).effectiveMicroUsdc, 7_500n);
+  assert.equal(sdk.priceForX402Tier(base, qGold).effectiveMicroUsdc, 0n);
+  assert.equal(sdk.priceForX402Tier(base, qDiamond).effectiveMicroUsdc, 0n);
+});
+
+test('qualifyX402OnChain calls staking.getTier with the manifest address', async () => {
+  let captured;
+  const stub = {
+    readContract: async (args) => {
+      captured = args;
+      return 2n;
+    },
+  };
+  const result = await sdk.qualifyX402OnChain({
+    client: stub,
+    network: 'production',
+    wallet: '0x1111111111111111111111111111111111111111',
+  });
+  assert.equal(
+    captured.address.toLowerCase(),
+    '0x709d6006f026950b531d4883260c8416650c5ab7',
+  );
+  assert.equal(captured.functionName, 'getTier');
+  assert.equal(captured.args[0], '0x1111111111111111111111111111111111111111');
+  assert.equal(result.tier.tier, 2);
+  assert.equal(result.bypassesX402, true);
+});
+
+test('qualifyX402OnChain accepts both bigint and number tier responses', async () => {
+  const numStub = {
+    readContract: async () => 1,
+  };
+  const numQual = await sdk.qualifyX402OnChain({
+    client: numStub,
+    network: 'production',
+    wallet: '0x1111111111111111111111111111111111111111',
+  });
+  assert.equal(numQual.tier.tier, 1);
+});
+
+test('Bronze tier (0) charges full price for x402', () => {
+  const q = sdk.qualifyX402FromStaked(0n);
+  const breakdown = sdk.priceForX402Tier(2_500n, q);
+  assert.equal(breakdown.baseMicroUsdc, 2_500n);
+  assert.equal(breakdown.effectiveMicroUsdc, 2_500n);
+  assert.equal(breakdown.qualification.bypassesX402, false);
+});

--- a/sdk/protocol/package.json
+++ b/sdk/protocol/package.json
@@ -27,6 +27,7 @@
     "generate": "node scripts/generate.mjs",
     "check": "node scripts/generate.mjs --check",
     "build": "tsc -p tsconfig.json",
+    "test": "npm run build && node --test test/*.test.mjs",
     "pack:dry": "npm pack --dry-run",
     "prepack": "npm run check && npm run build"
   },

--- a/sdk/protocol/src/index.ts
+++ b/sdk/protocol/src/index.ts
@@ -1,1 +1,2 @@
 export * from './generated';
+export * from './relay-utility';

--- a/sdk/protocol/src/relay-utility.ts
+++ b/sdk/protocol/src/relay-utility.ts
@@ -1,0 +1,103 @@
+// Static RELAY token utility metadata. Mirrors the constants defined in
+// `evm/src/RelayStaking.sol::getTier` and `evm/src/OrderBook.sol::TIERn_THRESHOLD`,
+// the runtime selectors in `app/src/services/staking.rs`, and the public response
+// shape from `GET /v1/protocol/relay-utility`.
+//
+// Address values are sourced from the generated deployment manifest so that this
+// file never duplicates the address constants.
+
+import {
+  type Address,
+  type NetworkName,
+  deploymentManifest,
+  getContractAddress,
+} from './generated';
+
+export const RELAY_DECIMALS = 18;
+
+/** Tier id at which an x402-priced request is fully bypassed (free access). */
+export const X402_BYPASS_TIER = 2;
+
+export type RelayTierId = 0 | 1 | 2 | 3;
+
+export interface RelayTier {
+  readonly tier: RelayTierId;
+  readonly name: 'Bronze' | 'Silver' | 'Gold' | 'Diamond';
+  /** Minimum staked RELAY (in wei, 18 decimals) to qualify for this tier. */
+  readonly minRelayWei: bigint;
+  /** Order-fee discount applied at match time, in bps (10_000 = 100%). */
+  readonly feeDiscountBps: number;
+  /** True if x402-priced API access is free for this tier. */
+  readonly x402Bypass: boolean;
+}
+
+export const RELAY_TIERS: readonly RelayTier[] = [
+  {
+    tier: 0,
+    name: 'Bronze',
+    minRelayWei: 0n,
+    feeDiscountBps: 0,
+    x402Bypass: false,
+  },
+  {
+    tier: 1,
+    name: 'Silver',
+    minRelayWei: 1_000n * 10n ** 18n,
+    feeDiscountBps: 2_500,
+    x402Bypass: false,
+  },
+  {
+    tier: 2,
+    name: 'Gold',
+    minRelayWei: 10_000n * 10n ** 18n,
+    feeDiscountBps: 5_000,
+    x402Bypass: true,
+  },
+  {
+    tier: 3,
+    name: 'Diamond',
+    minRelayWei: 100_000n * 10n ** 18n,
+    feeDiscountBps: 7_500,
+    x402Bypass: true,
+  },
+] as const;
+
+/** Returns the tier metadata for a given staked-RELAY balance (in wei). */
+export function relayTierFromStakedWei(stakedWei: bigint): RelayTier {
+  let match = RELAY_TIERS[0];
+  for (const tier of RELAY_TIERS) {
+    if (stakedWei >= tier.minRelayWei) {
+      match = tier;
+    }
+  }
+  return match;
+}
+
+/** Returns the tier metadata for a tier id (0..3). */
+export function relayTierById(tier: number): RelayTier {
+  const found = RELAY_TIERS.find((t) => t.tier === tier);
+  if (!found) {
+    throw new Error(`Unknown RELAY tier id: ${tier}`);
+  }
+  return found;
+}
+
+export interface RelayUtilityAddresses {
+  readonly token: Address;
+  readonly staking: Address;
+  readonly rewardDistributor: Address;
+}
+
+/** Returns the RELAY utility contract addresses for a deployed network. */
+export function getRelayUtilityAddresses(network: NetworkName): RelayUtilityAddresses {
+  return {
+    token: getContractAddress(network, 'relayToken'),
+    staking: getContractAddress(network, 'relayStaking'),
+    rewardDistributor: getContractAddress(network, 'rewardDistributor'),
+  };
+}
+
+/** Convenience: chain id for the requested deployment environment. */
+export function getRelayChainId(network: NetworkName): number {
+  return deploymentManifest.environments[network].chainId;
+}

--- a/sdk/protocol/test/relay-utility.test.mjs
+++ b/sdk/protocol/test/relay-utility.test.mjs
@@ -1,0 +1,73 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const protocol = await import('../dist/index.js');
+
+test('RELAY_TIERS exposes Bronze/Silver/Gold/Diamond in order', () => {
+  assert.equal(protocol.RELAY_TIERS.length, 4);
+  assert.equal(protocol.RELAY_TIERS[0].name, 'Bronze');
+  assert.equal(protocol.RELAY_TIERS[1].name, 'Silver');
+  assert.equal(protocol.RELAY_TIERS[2].name, 'Gold');
+  assert.equal(protocol.RELAY_TIERS[3].name, 'Diamond');
+});
+
+test('Tier thresholds match Solidity OrderBook constants', () => {
+  const wei = (n) => BigInt(n) * 10n ** 18n;
+  assert.equal(protocol.RELAY_TIERS[0].minRelayWei, 0n);
+  assert.equal(protocol.RELAY_TIERS[1].minRelayWei, wei(1_000));
+  assert.equal(protocol.RELAY_TIERS[2].minRelayWei, wei(10_000));
+  assert.equal(protocol.RELAY_TIERS[3].minRelayWei, wei(100_000));
+});
+
+test('Fee discount bps match Solidity OrderBook getDiscountBps', () => {
+  assert.equal(protocol.RELAY_TIERS[0].feeDiscountBps, 0);
+  assert.equal(protocol.RELAY_TIERS[1].feeDiscountBps, 2_500);
+  assert.equal(protocol.RELAY_TIERS[2].feeDiscountBps, 5_000);
+  assert.equal(protocol.RELAY_TIERS[3].feeDiscountBps, 7_500);
+});
+
+test('x402 bypass kicks in at tier 2+', () => {
+  assert.equal(protocol.X402_BYPASS_TIER, 2);
+  assert.equal(protocol.RELAY_TIERS[0].x402Bypass, false);
+  assert.equal(protocol.RELAY_TIERS[1].x402Bypass, false);
+  assert.equal(protocol.RELAY_TIERS[2].x402Bypass, true);
+  assert.equal(protocol.RELAY_TIERS[3].x402Bypass, true);
+});
+
+test('relayTierFromStakedWei resolves correct tier for boundary values', () => {
+  const wei = (n) => BigInt(n) * 10n ** 18n;
+  assert.equal(protocol.relayTierFromStakedWei(0n).tier, 0);
+  assert.equal(protocol.relayTierFromStakedWei(wei(999)).tier, 0);
+  assert.equal(protocol.relayTierFromStakedWei(wei(1_000)).tier, 1);
+  assert.equal(protocol.relayTierFromStakedWei(wei(9_999)).tier, 1);
+  assert.equal(protocol.relayTierFromStakedWei(wei(10_000)).tier, 2);
+  assert.equal(protocol.relayTierFromStakedWei(wei(99_999)).tier, 2);
+  assert.equal(protocol.relayTierFromStakedWei(wei(100_000)).tier, 3);
+  assert.equal(protocol.relayTierFromStakedWei(wei(1_000_000_000)).tier, 3);
+});
+
+test('relayTierById returns metadata for known tiers and throws otherwise', () => {
+  for (let i = 0; i < 4; i++) {
+    assert.equal(protocol.relayTierById(i).tier, i);
+  }
+  assert.throws(() => protocol.relayTierById(99), /Unknown RELAY tier/);
+});
+
+test('getRelayUtilityAddresses returns the production addresses from the manifest', () => {
+  const addrs = protocol.getRelayUtilityAddresses('production');
+  assert.equal(addrs.token.toLowerCase(), '0x580ff5ae64ec792a949c6123386a8a936c7ebb07');
+  assert.equal(addrs.staking.toLowerCase(), '0x709d6006f026950b531d4883260c8416650c5ab7');
+  assert.equal(
+    addrs.rewardDistributor.toLowerCase(),
+    '0x3c4c0a74f9d108f966908a835a9b4b8d946bbce3',
+  );
+});
+
+test('getRelayChainId returns 8453 for production and 84532 for staging', () => {
+  assert.equal(protocol.getRelayChainId('production'), 8453);
+  assert.equal(protocol.getRelayChainId('staging'), 84532);
+});
+
+test('RELAY_DECIMALS is 18', () => {
+  assert.equal(protocol.RELAY_DECIMALS, 18);
+});

--- a/web/src/app/docs/developers/quickstart/page.tsx
+++ b/web/src/app/docs/developers/quickstart/page.tsx
@@ -38,6 +38,34 @@ const FETCH_MARKETS = `curl 'https://relay44-api.onrender.com/v1/evm/markets?lim
 
 const PROTOCOL_METRICS = `curl https://relay44-api.onrender.com/v1/protocol/metrics | jq`;
 
+const RELAY_UTILITY = `curl https://relay44-api.onrender.com/v1/protocol/relay-utility | jq`;
+
+const CHECK_STAKING_TIER = `import { createPublicClient, http } from 'viem';
+import { base } from 'viem/chains';
+import {
+  qualifyX402OnChain,
+  priceForX402Tier,
+} from '@relay44/agent-sdk';
+
+const client = createPublicClient({
+  chain: base,
+  transport: http('https://mainnet.base.org'),
+});
+
+const qualification = await qualifyX402OnChain({
+  client,
+  network: 'production',
+  wallet: '0xYourWallet',
+});
+
+console.log(qualification.tier.name);          // Bronze | Silver | Gold | Diamond
+console.log(qualification.bypassesX402);        // true at Gold and above
+console.log(qualification.x402DiscountBps);     // 0, 2500, or 10000
+
+// Compute what an x402-priced endpoint would charge this wallet:
+const breakdown = priceForX402Tier(2_500n, qualification);
+console.log(breakdown.effectiveMicroUsdc);      // 0n at Gold+, 1875n at Silver`;
+
 const AUTHENTICATE = `curl https://relay44-api.onrender.com/v1/auth/siwe/nonce
 
 curl -X POST https://relay44-api.onrender.com/v1/auth/siwe/login \\
@@ -140,7 +168,37 @@ export default function QuickstartPage() {
 
         <Card className="p-6">
           <h2 className="text-lg font-semibold text-text-primary">
-            5. Authenticate for trading
+            5. Read RELAY utility metadata
+          </h2>
+          <p className="mt-2 text-sm leading-6 text-text-secondary">
+            Returns chain id, RELAY token state, total staked, the four-tier
+            table with fee-discount bps and x402 bypass flags, and the reward
+            distributor address. Use this to render a tier badge or to size
+            x402 payments without hard-coding constants.
+          </p>
+          <div className="mt-4">
+            <CodeBlock language="bash" code={RELAY_UTILITY} />
+          </div>
+        </Card>
+
+        <Card className="p-6">
+          <h2 className="text-lg font-semibold text-text-primary">
+            6. Check a wallet&apos;s staking tier and x402 access
+          </h2>
+          <p className="mt-2 text-sm leading-6 text-text-secondary">
+            The agent SDK reads <code>RelayStaking.getTier</code> on Base and
+            returns the tier metadata, x402 bypass flag, and effective price
+            for an x402-quoted endpoint. Equivalent to the server-side staking
+            check the API performs before charging an agent.
+          </p>
+          <div className="mt-4">
+            <CodeBlock language="typescript" code={CHECK_STAKING_TIER} />
+          </div>
+        </Card>
+
+        <Card className="p-6">
+          <h2 className="text-lg font-semibold text-text-primary">
+            7. Authenticate for trading
           </h2>
           <p className="mt-2 text-sm leading-6 text-text-secondary">
             Trading requires a SIWE JWT. The API never takes custody of keys.
@@ -152,7 +210,7 @@ export default function QuickstartPage() {
 
         <Card className="p-6">
           <h2 className="text-lg font-semibold text-text-primary">
-            6. Read an order book
+            8. Read an order book
           </h2>
           <p className="mt-2 text-sm leading-6 text-text-secondary">
             Market data is public and works without wallet auth.
@@ -164,7 +222,7 @@ export default function QuickstartPage() {
 
         <Card className="p-6">
           <h2 className="text-lg font-semibold text-text-primary">
-            7. Place an order
+            9. Place an order
           </h2>
           <p className="mt-2 text-sm leading-6 text-text-secondary">
             Use the JWT from SIWE auth. Wallet-signed EVM write flows are exposed

--- a/web/src/app/docs/protocol/page.tsx
+++ b/web/src/app/docs/protocol/page.tsx
@@ -36,6 +36,12 @@ const pages = [
     href: '/docs/developers/quickstart',
   },
   {
+    title: '$RELAY Utility',
+    description:
+      'Canonical reference for the RELAY token surface — staking tiers, fee discounts, free x402 access at Gold and above, the public utility endpoint, and importable SDK constants.',
+    href: '/docs/protocol/relay-utility',
+  },
+  {
     title: 'Technical Roadmap',
     description:
       'Architect-level deep dive — system layers, core subsystems, design principles, eight concrete technical workstreams, and the invariants that shape every decision.',

--- a/web/src/app/docs/protocol/relay-utility/page.tsx
+++ b/web/src/app/docs/protocol/relay-utility/page.tsx
@@ -1,0 +1,273 @@
+import Link from 'next/link';
+
+import { StructuredData } from '@/components/seo/StructuredData';
+import { CodeBlock } from '@/components/docs';
+import { Card } from '@/components/ui';
+import {
+  buildBreadcrumbStructuredData,
+  buildPageMetadata,
+  buildWebPageStructuredData,
+} from '@/lib/seo';
+import {
+  PROTOCOL_NETWORKS,
+  STAKING_TIERS,
+  basescanAddressUrl,
+} from '@/lib/protocol';
+
+export const metadata = buildPageMetadata({
+  title: '$RELAY Utility',
+  description:
+    'How $RELAY is used in the Relay44 Protocol on Base — staking tiers, fee discounts, free x402 access, reward eligibility, and the public utility endpoint and SDK exports for humans and agents.',
+  path: '/docs/protocol/relay-utility',
+  keywords: ['relay token', 'utility', 'staking', 'x402', 'fee discount', 'base'],
+});
+
+const prod = PROTOCOL_NETWORKS.production;
+
+const ENDPOINT = `curl https://relay44-api.onrender.com/v1/protocol/relay-utility | jq`;
+
+const ENDPOINT_RESPONSE = `{
+  "chainId": 8453,
+  "token": {
+    "address": "0x580ff5ae64ec792a949c6123386a8a936c7ebb07",
+    "totalSupplyHex": "0x...",
+    "decimals": 18
+  },
+  "staking": {
+    "address": "0x709d6006f026950b531d4883260c8416650c5ab7",
+    "totalStakedHex": "0x...",
+    "tiers": [
+      { "tier": 0, "name": "Bronze",  "minRelayWei": "0",                          "feeDiscountBps": 0,    "x402Bypass": false },
+      { "tier": 1, "name": "Silver",  "minRelayWei": "1000000000000000000000",     "feeDiscountBps": 2500, "x402Bypass": false },
+      { "tier": 2, "name": "Gold",    "minRelayWei": "10000000000000000000000",    "feeDiscountBps": 5000, "x402Bypass": true  },
+      { "tier": 3, "name": "Diamond", "minRelayWei": "100000000000000000000000",   "feeDiscountBps": 7500, "x402Bypass": true  }
+    ],
+    "x402BypassTier": 2
+  },
+  "rewardDistributor": {
+    "address": "0x3c4c0a74f9d108f966908a835a9b4b8d946bbce3"
+  },
+  "flags": {
+    "feeDiscount": true,
+    "x402Discount": true,
+    "stakingRewards": true,
+    "agentRewards": true,
+    "creatorRewards": true,
+    "governance": false
+  },
+  "source": "relay44-api",
+  "updatedAt": "2026-04-26T..."
+}`;
+
+const SDK_USAGE = `import {
+  RELAY_TIERS,
+  X402_BYPASS_TIER,
+  getRelayUtilityAddresses,
+  relayTierFromStakedWei,
+} from '@relay44/protocol';
+
+const { token, staking, rewardDistributor } = getRelayUtilityAddresses('production');
+
+// Inspect tier metadata without an RPC call:
+for (const tier of RELAY_TIERS) {
+  console.log(tier.name, tier.minRelayWei.toString(), tier.feeDiscountBps);
+}
+
+// Resolve a tier from a wallet's staked balance (wei, 18 decimals):
+const tier = relayTierFromStakedWei(15_000n * 10n ** 18n);
+console.log(tier.name);          // 'Gold'
+console.log(tier.x402Bypass);    // true`;
+
+const AGENT_USAGE = `import { createPublicClient, http } from 'viem';
+import { base } from 'viem/chains';
+import { qualifyX402OnChain, priceForX402Tier } from '@relay44/agent-sdk';
+
+const client = createPublicClient({ chain: base, transport: http() });
+
+const qualification = await qualifyX402OnChain({
+  client,
+  network: 'production',
+  wallet: '0xYourAgentWallet',
+});
+
+if (qualification.bypassesX402) {
+  // Tier >= Gold: paid endpoints are free for this wallet.
+  return fetch(endpoint);
+}
+
+// Otherwise, compute the discounted price the API will quote:
+const breakdown = priceForX402Tier(2_500n /* base price in micro-USDC */, qualification);
+console.log(breakdown.effectiveMicroUsdc);`;
+
+export default function RelayUtilityPage() {
+  return (
+    <>
+      <StructuredData
+        data={[
+          buildWebPageStructuredData({
+            path: '/docs/protocol/relay-utility',
+            name: '$RELAY Utility',
+            description:
+              'How $RELAY is used in the Relay44 Protocol — staking, fee discounts, x402 access, rewards.',
+          }),
+          buildBreadcrumbStructuredData([
+            { name: 'Home', url: '/' },
+            { name: 'Docs', url: '/docs' },
+            { name: 'Protocol', url: '/docs/protocol' },
+            { name: '$RELAY Utility', url: '/docs/protocol/relay-utility' },
+          ]),
+        ]}
+      />
+
+      <h1 className="text-3xl font-semibold text-text-primary sm:text-4xl">
+        $RELAY Utility
+      </h1>
+      <p className="mt-4 max-w-3xl text-base leading-7 text-text-secondary">
+        $RELAY exists to reduce protocol costs and unlock machine-facing access
+        on Relay44. Stakers get on-chain order-fee discounts, free x402 API
+        access at Gold and above, and eligibility for per-epoch reward
+        distributions. This page is the canonical reference for humans and
+        agents — the same constants and addresses are exposed via a public
+        endpoint and via importable packages.
+      </p>
+
+      <Card className="mt-8 p-6">
+        <h2 className="text-lg font-semibold text-text-primary">
+          What $RELAY does today
+        </h2>
+        <div className="mt-4 grid gap-6 md:grid-cols-2">
+          <div>
+            <p className="text-[0.65rem] uppercase tracking-[0.2em] text-text-muted">
+              Enforced on-chain
+            </p>
+            <ul className="mt-2 space-y-1 text-sm leading-6 text-text-secondary">
+              <li>• Order-fee discount by staking tier in OrderBook</li>
+              <li>• Stake / unstake / claim flows in RelayStaking</li>
+              <li>• Per-share reward accounting in RelayStaking</li>
+              <li>• Claim paths for agent and creator rewards</li>
+            </ul>
+          </div>
+          <div>
+            <p className="text-[0.65rem] uppercase tracking-[0.2em] text-text-muted">
+              Enforced server-side
+            </p>
+            <ul className="mt-2 space-y-1 text-sm leading-6 text-text-secondary">
+              <li>• x402 fee bypass at tier ≥ Gold</li>
+              <li>• x402 discount at Silver (25%)</li>
+              <li>• Per-tier price quoted by <code>/v1/payments/x402/quote</code></li>
+            </ul>
+          </div>
+        </div>
+      </Card>
+
+      <Card className="mt-6 p-6">
+        <h2 className="text-lg font-semibold text-text-primary">Tier table</h2>
+        <p className="mt-2 max-w-3xl text-sm leading-6 text-text-secondary">
+          Tiers are read from{' '}
+          <a
+            href={basescanAddressUrl(prod.contracts.relayStaking!, 'production')}
+            target="_blank"
+            rel="noreferrer"
+            className="font-mono text-text-primary underline-offset-2 hover:underline"
+          >
+            RelayStaking.getTier(address)
+          </a>
+          . The same thresholds back the <code>RELAY_TIERS</code> export in{' '}
+          <code>@relay44/protocol</code>.
+        </p>
+        <div className="mt-4 overflow-hidden border border-border">
+          <div className="grid grid-cols-12 gap-4 border-b border-border bg-bg-secondary px-4 py-3 text-[0.65rem] uppercase tracking-[0.2em] text-text-muted">
+            <span className="col-span-3">Tier</span>
+            <span className="col-span-3">Minimum RELAY</span>
+            <span className="col-span-2">Fee discount</span>
+            <span className="col-span-4">x402 access</span>
+          </div>
+          {STAKING_TIERS.map((tier, i) => (
+            <div
+              key={tier.name}
+              className="grid grid-cols-12 gap-4 border-b border-border px-4 py-4 text-xs text-text-secondary last:border-b-0"
+            >
+              <span className="col-span-3 text-sm font-semibold text-text-primary">
+                {tier.name}
+              </span>
+              <code className="col-span-3 text-text-primary">{tier.min}</code>
+              <code className="col-span-2 text-text-primary">{tier.feeDiscount}</code>
+              <span className="col-span-4">
+                {i >= 2 ? 'Free (bypass)' : i === 1 ? '25% discount' : 'Full price'}
+              </span>
+            </div>
+          ))}
+        </div>
+      </Card>
+
+      <Card className="mt-6 p-6">
+        <h2 className="text-lg font-semibold text-text-primary">
+          Public endpoint
+        </h2>
+        <p className="mt-2 max-w-3xl text-sm leading-6 text-text-secondary">
+          The single-call utility endpoint returns chain id, RELAY token state
+          (totalSupply + decimals), staking address, totalStaked, the four-tier
+          table, the reward distributor address, and live utility flags. Safe to
+          cache for tens of seconds; updates every block-relevant read.
+        </p>
+        <div className="mt-4 grid gap-4">
+          <CodeBlock language="bash" code={ENDPOINT} />
+          <CodeBlock language="json" code={ENDPOINT_RESPONSE} />
+        </div>
+      </Card>
+
+      <Card className="mt-6 p-6">
+        <h2 className="text-lg font-semibold text-text-primary">
+          TypeScript: <code>@relay44/protocol</code>
+        </h2>
+        <p className="mt-2 max-w-3xl text-sm leading-6 text-text-secondary">
+          Tier thresholds use <code>bigint</code> to preserve precision past{' '}
+          <code>Number.MAX_SAFE_INTEGER</code> and mirror the Solidity
+          constants. Addresses come from the deployment manifest so frontends
+          and agents never duplicate them.
+        </p>
+        <div className="mt-4">
+          <CodeBlock language="typescript" code={SDK_USAGE} />
+        </div>
+      </Card>
+
+      <Card className="mt-6 p-6">
+        <h2 className="text-lg font-semibold text-text-primary">
+          Agents: <code>@relay44/agent-sdk</code>
+        </h2>
+        <p className="mt-2 max-w-3xl text-sm leading-6 text-text-secondary">
+          Agents can resolve their own x402 access state without re-encoding
+          tier constants. <code>qualifyX402OnChain</code> reads tier from the
+          deployed RelayStaking address;{' '}
+          <code>priceForX402Tier</code> mirrors the Rust{' '}
+          <code>discounted_amount</code> math so client-side price expectations
+          stay aligned with the API.
+        </p>
+        <div className="mt-4">
+          <CodeBlock language="typescript" code={AGENT_USAGE} />
+        </div>
+      </Card>
+
+      <div className="mt-8 flex flex-wrap gap-3">
+        <Link
+          href="/tokenomics"
+          className="inline-flex h-10 items-center border border-border bg-bg-secondary px-5 text-xs uppercase tracking-widest text-text-primary transition-colors hover:border-border-hover"
+        >
+          Tokenomics
+        </Link>
+        <Link
+          href="/staking"
+          className="inline-flex h-10 items-center border border-border px-5 text-xs uppercase tracking-widest text-text-secondary transition-colors hover:border-border-hover hover:text-text-primary"
+        >
+          Stake $RELAY
+        </Link>
+        <Link
+          href="/docs/contracts#relayStaking"
+          className="inline-flex h-10 items-center border border-border px-5 text-xs uppercase tracking-widest text-text-secondary transition-colors hover:border-border-hover hover:text-text-primary"
+        >
+          Contract reference
+        </Link>
+      </div>
+    </>
+  );
+}

--- a/web/src/app/protocol/page.tsx
+++ b/web/src/app/protocol/page.tsx
@@ -26,6 +26,34 @@ interface ProtocolMetricsResponse {
   updatedAt: string;
 }
 
+interface RelayUtilityResponse {
+  chainId: number;
+  token: { address: string; totalSupplyHex: string; decimals: number };
+  staking: {
+    address: string;
+    totalStakedHex: string;
+    tiers: Array<{
+      tier: number;
+      name: string;
+      minRelayWei: string;
+      feeDiscountBps: number;
+      x402Bypass: boolean;
+    }>;
+    x402BypassTier: number;
+  };
+  rewardDistributor: { address: string };
+  flags: {
+    feeDiscount: boolean;
+    x402Discount: boolean;
+    stakingRewards: boolean;
+    agentRewards: boolean;
+    creatorRewards: boolean;
+    governance: boolean;
+  };
+  source: string;
+  updatedAt: string;
+}
+
 function apiBase() {
   return (
     process.env.NEXT_PUBLIC_API_URL?.trim() ||
@@ -46,10 +74,41 @@ async function loadMetrics(): Promise<ProtocolMetricsResponse | null> {
   }
 }
 
+async function loadRelayUtility(): Promise<RelayUtilityResponse | null> {
+  try {
+    const response = await fetch(`${apiBase()}/protocol/relay-utility`, {
+      next: { revalidate: 60 },
+      headers: { accept: 'application/json' },
+    });
+    if (!response.ok) return null;
+    return (await response.json()) as RelayUtilityResponse;
+  } catch {
+    return null;
+  }
+}
+
 function formatNumber(value: number) {
   return new Intl.NumberFormat('en-US', {
     maximumFractionDigits: value >= 1000 ? 0 : 2,
   }).format(value);
+}
+
+function hexToTokenAmount(hex: string, decimals: number): number {
+  if (!hex) return 0;
+  try {
+    const wei = BigInt(hex);
+    const scale = BigInt(10) ** BigInt(decimals);
+    const whole = wei / scale;
+    const fraction = wei % scale;
+    return Number(whole) + Number(fraction) / Number(scale);
+  } catch {
+    return 0;
+  }
+}
+
+function shortAddress(address: string): string {
+  if (!address || address.length < 10) return address;
+  return `${address.slice(0, 6)}…${address.slice(-4)}`;
 }
 
 function MetricCard({
@@ -73,7 +132,14 @@ function MetricCard({
 }
 
 export default async function ProtocolDashboardPage() {
-  const metrics = await loadMetrics();
+  const [metrics, relay] = await Promise.all([loadMetrics(), loadRelayUtility()]);
+  const totalSupply = relay
+    ? hexToTokenAmount(relay.token.totalSupplyHex, relay.token.decimals)
+    : 0;
+  const totalStaked = relay
+    ? hexToTokenAmount(relay.staking.totalStakedHex, relay.token.decimals)
+    : 0;
+  const stakedShare = totalSupply > 0 ? (totalStaked / totalSupply) * 100 : 0;
 
   return (
     <>
@@ -150,6 +216,119 @@ export default async function ProtocolDashboardPage() {
             }
             note="Collateral tracked by market tables where available."
           />
+        </div>
+
+        <div className="mt-12">
+          <div className="flex flex-wrap items-end justify-between gap-3">
+            <div>
+              <p className="text-[0.7rem] uppercase tracking-[0.22em] text-accent">
+                $RELAY
+              </p>
+              <h2 className="mt-1 text-2xl font-semibold text-text-primary sm:text-3xl">
+                Token utility, on-chain.
+              </h2>
+            </div>
+            <Link
+              href="/docs/protocol/relay-utility"
+              className="inline-flex h-9 items-center border border-border px-4 text-xs uppercase tracking-[0.16em] text-text-primary transition-colors hover:border-border-hover hover:bg-bg-secondary"
+            >
+              Utility reference
+            </Link>
+          </div>
+
+          <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <MetricCard
+              label="Total Supply"
+              value={
+                relay ? `${formatNumber(totalSupply)} RELAY` : 'Pending deploy'
+              }
+              note={
+                relay
+                  ? `Cap-enforced ERC20 at ${shortAddress(relay.token.address)}.`
+                  : 'Reads RelayToken.totalSupply from Base mainnet.'
+              }
+            />
+            <MetricCard
+              label="Total Staked"
+              value={
+                relay
+                  ? `${formatNumber(totalStaked)} RELAY`
+                  : 'Pending deploy'
+              }
+              note={
+                relay && stakedShare > 0
+                  ? `~${stakedShare.toFixed(1)}% of supply at ${shortAddress(relay.staking.address)}.`
+                  : 'Reads RelayStaking.totalStaked from Base mainnet.'
+              }
+            />
+            <MetricCard
+              label="Reward Distributor"
+              value={relay ? shortAddress(relay.rewardDistributor.address) : 'Pending'}
+              note="Per-epoch split between stakers, agents, creators, treasury."
+            />
+            <MetricCard
+              label="x402 Bypass"
+              value={
+                relay
+                  ? `Tier ${relay.staking.x402BypassTier}+`
+                  : 'Pending deploy'
+              }
+              note="Free machine-facing API access at Gold and Diamond tiers."
+            />
+          </div>
+
+          {relay ? (
+            <div className="mt-6 overflow-hidden border border-border">
+              <div className="grid grid-cols-12 gap-4 border-b border-border bg-bg-secondary px-4 py-3 text-[0.65rem] uppercase tracking-[0.2em] text-text-muted">
+                <span className="col-span-3">Tier</span>
+                <span className="col-span-3">Minimum RELAY</span>
+                <span className="col-span-3">Fee discount</span>
+                <span className="col-span-3">x402 access</span>
+              </div>
+              {relay.staking.tiers.map((tier) => {
+                const min = hexToTokenAmount(
+                  '0x' + BigInt(tier.minRelayWei).toString(16),
+                  relay.token.decimals,
+                );
+                return (
+                  <div
+                    key={tier.tier}
+                    className="grid grid-cols-12 gap-4 border-b border-border px-4 py-4 text-xs text-text-secondary last:border-b-0"
+                  >
+                    <span className="col-span-3 text-sm font-semibold text-text-primary">
+                      {tier.name}
+                    </span>
+                    <code className="col-span-3 text-text-primary">
+                      {min === 0 ? '0' : formatNumber(min)}
+                    </code>
+                    <code className="col-span-3 text-text-primary">
+                      {(tier.feeDiscountBps / 100).toFixed(0)}%
+                    </code>
+                    <span className="col-span-3">
+                      {tier.x402Bypass ? 'Free (bypass)' : tier.feeDiscountBps > 0 ? '25% discount' : 'Full price'}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          ) : null}
+
+          <div className="mt-4 flex flex-wrap gap-2 text-[0.65rem] uppercase tracking-[0.18em] text-text-muted">
+            {relay
+              ? Object.entries(relay.flags).map(([key, on]) => (
+                  <span
+                    key={key}
+                    className={`border px-2 py-1 ${
+                      on
+                        ? 'border-accent text-accent'
+                        : 'border-border text-text-muted'
+                    }`}
+                  >
+                    {key.replace(/([A-Z])/g, ' $1').trim()} · {on ? 'live' : 'roadmap'}
+                  </span>
+                ))
+              : null}
+          </div>
         </div>
 
         <div className="mt-8 grid gap-6 lg:grid-cols-[1.2fr_0.8fr]">

--- a/web/src/app/tokenomics/page.tsx
+++ b/web/src/app/tokenomics/page.tsx
@@ -61,11 +61,12 @@ export default function TokenomicsPage() {
           $RELAY Tokenomics
         </h1>
         <p className="max-w-3xl text-base leading-7 text-text-secondary">
-          $RELAY is the economic core of the Relay44 Protocol. Traders pay order
-          book fees in USDC, a keeper swaps those fees into RELAY and burns a
-          share, agents compete for per-epoch reward allocations, and stakers
-          lock RELAY to capture a cut of protocol revenue — all on Base, all
-          open source.
+          Hold and stake $RELAY to reduce protocol fees and access the
+          machine-facing infrastructure on Relay44 — order-book fee discounts,
+          free x402 API access at Gold and above, and eligibility for per-epoch
+          reward distributions. A keeper-operated pipeline converts protocol
+          fees into RELAY and routes them through a public reward distributor
+          on Base.
         </p>
         <div className="flex flex-wrap gap-3 pt-2">
           <a
@@ -84,6 +85,40 @@ export default function TokenomicsPage() {
           </Link>
         </div>
       </div>
+
+      {/* ---------------- Live status ---------------- */}
+      <Card className="mt-10 p-6">
+        <h2 className="text-lg font-semibold text-text-primary">What is live today</h2>
+        <div className="mt-4 grid gap-6 md:grid-cols-2">
+          <div>
+            <p className="text-[0.65rem] uppercase tracking-[0.2em] text-text-muted">
+              Enforced on-chain
+            </p>
+            <ul className="mt-2 space-y-1 text-sm leading-6 text-text-secondary">
+              <li>• ERC20 + Permit + Capped supply for $RELAY</li>
+              <li>• Order-fee discount by staking tier in OrderBook</li>
+              <li>• Stake / unstake / claim flows in RelayStaking</li>
+              <li>• Per-epoch reward accounting in RewardDistributor</li>
+            </ul>
+          </div>
+          <div>
+            <p className="text-[0.65rem] uppercase tracking-[0.2em] text-text-muted">
+              Keeper-operated
+            </p>
+            <ul className="mt-2 space-y-1 text-sm leading-6 text-text-secondary">
+              <li>• Fee sweep from OrderBook to keeper (every 6 hours)</li>
+              <li>• USDC → RELAY swap on Aerodrome above the threshold</li>
+              <li>• Burn share routed to <code className="font-mono">0x…dEaD</code></li>
+              <li>• <code className="font-mono">distribute()</code> called once per epoch</li>
+            </ul>
+          </div>
+        </div>
+        <p className="mt-4 text-xs leading-5 text-text-muted">
+          Keeper schedules and burn share are operator parameters, not contract
+          invariants — they can be paused or retuned without a contract upgrade.
+          The on-chain trail is observable on Basescan.
+        </p>
+      </Card>
 
       {/* ---------------- Token summary ---------------- */}
       <div className="mt-10 grid gap-6 sm:grid-cols-2">
@@ -192,13 +227,16 @@ export default function TokenomicsPage() {
               <div>
                 <p className="text-text-primary font-semibold">USDC → RELAY swap + burn</p>
                 <p>
-                  The keeper swaps USDC for RELAY on Aerodrome, permanently burns a
-                  configurable share (currently{' '}
-                  <code className="font-mono text-text-primary">20%</code>) to{' '}
-                  <code className="font-mono text-text-primary">0x...dEaD</code>,
+                  When accrued USDC clears the keeper threshold, the pipeline
+                  swaps USDC for RELAY on Aerodrome, sends a configurable share
+                  (currently set to{' '}
+                  <code className="font-mono text-text-primary">20%</code> via{' '}
+                  <code className="font-mono text-text-primary">BUYBACK_BURN_SHARE_BPS</code>) to{' '}
+                  <code className="font-mono text-text-primary">0x…dEaD</code>,
                   and forwards the remainder to the RewardDistributor at{' '}
-                  <AddressInline address={rewardDistributor} />. Every trade
-                  becomes structural buy pressure on $RELAY plus a supply sink.
+                  <AddressInline address={rewardDistributor} />. The burn share
+                  and pipeline cadence are operator parameters and can be
+                  retuned without a contract upgrade.
                 </p>
               </div>
             </li>


### PR DESCRIPTION
## Summary

Six commits delivering the Week 1–3 concrete code work from the four-week
\$RELAY utility sprint plan. Defers human-gated items (npm scope, prod
smoke, v0.2.0 cut, X post, dependabot triage) to a local blockers file.

- **Backend** — new `GET /v1/protocol/relay-utility` returning chain id,
  RELAY token state (`totalSupplyHex` + decimals), staking address with
  `totalStakedHex` + the four-tier table (Bronze/Silver/Gold/Diamond) with
  fee-discount bps and x402 bypass flags, the reward distributor address,
  and live utility flags. Tier metadata moves into `services::staking`
  and is locked to the Solidity constants by unit tests so future drift
  is caught at compile time. `REWARD_DISTRIBUTOR_ADDRESS` is plumbed
  through `AppConfig` (already present in `.env.example` and `render.yaml`).
- **`@relay44/protocol`** — new static `relay-utility.ts` module exporting
  `RELAY_TIERS`, `X402_BYPASS_TIER`, `RELAY_DECIMALS`,
  `relayTierFromStakedWei`, `relayTierById`, `getRelayUtilityAddresses`,
  `getRelayChainId`. Tier thresholds use `bigint` to avoid Number-precision
  loss. Adds a `node:test` suite (no extra deps) that pins thresholds and
  bps to the Solidity OrderBook / RelayStaking constants.
- **`@relay44/agent-sdk`** — `qualifyX402ByTier`, `qualifyX402FromStaked`,
  `qualifyX402OnChain` (any viem-compatible client), and
  `priceForX402Tier`, mirroring the Rust `discounted_amount` math so
  client-side price expectations stay aligned with `services::x402`.
- **`/tokenomics`** — clear separation between on-chain enforcement and
  keeper-driven steps; hero copy now leads with the user-facing utility
  (fee discounts, free x402 access at Gold+, reward eligibility) instead
  of implying buybacks are contract-enforced; the swap+burn step names
  the operator parameter (`BUYBACK_BURN_SHARE_BPS`) so future retunes
  don't quietly contradict stale copy.
- **`/docs/protocol/relay-utility`** — new canonical reference page for
  humans and agents, with the live status, the four-tier table sourced
  from the endpoint, an example response, and TS snippets for both
  packages.
- **`/docs/developers/quickstart`** — two new steps walking through the
  utility endpoint and on-chain staking-tier checks.
- **`/protocol` dashboard** — new \$RELAY block: total supply, total
  staked + share of supply, reward distributor, x402 bypass tier; tier
  table from the endpoint; utility-flag pills tagged \`live\` vs
  \`roadmap\`.

## Test plan

- [x] \`cargo test -p relay44-backend --lib\` — **521 passed** (7 new)
- [x] \`cargo clippy -p relay44-backend --lib -- -D warnings\` — clean
- [x] \`npm --workspace @relay44/protocol run test\` — **9 passed**
- [x] \`npm --workspace @relay44/agent-sdk run build\` + \`node --test\` — **6 passed**
- [x] \`npx next build\` in \`web/\` — \`/protocol\`, \`/tokenomics\`,
      \`/docs/protocol/relay-utility\`, \`/docs/developers/quickstart\` all build
- [ ] Production smoke (post-deploy): \`/v1/protocol/relay-utility\`,
      \`/protocol\`, \`/staking\`, \`/tokenomics\`,
      \`/docs/protocol/relay-utility\`, x402 quote, WebSocket
- [ ] \`npm install @relay44/protocol\` from a clean temp project after the
      next publish (gated on the \`@relay44\` npm scope being live)

## Notes for review

- No new env vars: \`REWARD_DISTRIBUTOR_ADDRESS\` was already in
  \`.env.example\` and \`render.yaml\`. The endpoint returns a clear
  \`INVALID_REWARD_DISTRIBUTOR_ADDRESS\` if missing on a given service.
- The endpoint is read-only and rejects when EVM reads are disabled,
  matching the existing \`/v1/evm/token/state\` guard.
- Tier constants are duplicated across Rust, TS-protocol, and Solidity
  by design — each layer owns its source of truth, and the test suites
  on each side pin the values, so a one-side change fails CI.