### PR TITLE
telegram bot reliability: silence noise, retry sends, multi-chat digest, persist nonces

### DIFF
--- a/app/src/services/digest_scheduler.rs
+++ b/app/src/services/digest_scheduler.rs
@@ -16,7 +16,7 @@
 //! — a $100k book moving 10 pts outranks a $5k book moving 12 pts, but a
 //! very fresh signal still beats an older one with similar economics.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -53,11 +53,12 @@ pub fn spawn(state: Arc<AppState>) {
     let interval_secs = env_u64("DIGEST_INTERVAL_SECS", DEFAULT_INTERVAL_SECS).max(60);
     let top_n = env_usize("DIGEST_TOP_N", DEFAULT_TOP_N).max(1);
     let cooldown_secs = env_u64("DIGEST_MARKET_COOLDOWN_SECS", DEFAULT_MARKET_COOLDOWN_SECS);
-    let parsed_chat_id: Option<i64> = chat_id.parse().ok();
+    let env_threshold = env_f64("PROB_ALERT_THRESHOLD_PCT", 5.0);
+    let parsed_env_chat_id: Option<i64> = chat_id.parse().ok();
 
     info!(
-        "Starting digest scheduler (interval={}s, top_n={}, market_cooldown={}s)",
-        interval_secs, top_n, cooldown_secs
+        "Starting digest scheduler (interval={}s, top_n={}, market_cooldown={}s, env_threshold={}%)",
+        interval_secs, top_n, cooldown_secs, env_threshold
     );
 
     let tg = TelegramClient::new(bot_token, chat_id);
@@ -67,7 +68,10 @@ pub fn spawn(state: Arc<AppState>) {
         // Skip the immediate tick — give the bus time to accumulate.
         interval.tick().await;
 
-        let mut last_alerted: HashMap<String, u64> = HashMap::new();
+        // Per-chat cooldown — keyed on (chat_id, market_dedup_key). A chat
+        // that just received an alert about a market doesn't block other
+        // chats from seeing the same market.
+        let mut last_alerted: HashMap<(i64, String), u64> = HashMap::new();
 
         loop {
             interval.tick().await;
@@ -76,7 +80,8 @@ pub fn spawn(state: Arc<AppState>) {
                 &tg,
                 top_n,
                 cooldown_secs,
-                parsed_chat_id,
+                env_threshold,
+                parsed_env_chat_id,
                 &mut last_alerted,
             )
             .await;
@@ -89,63 +94,137 @@ async fn run_tick(
     tg: &TelegramClient,
     top_n: usize,
     cooldown_secs: u64,
-    chat_id: Option<i64>,
-    last_alerted: &mut HashMap<String, u64>,
+    env_threshold: f64,
+    env_chat_id: Option<i64>,
+    last_alerted: &mut HashMap<(i64, String), u64>,
 ) {
-    // Per-chat quiet window: if the destination chat is snoozed, drop
-    // the whole tick. Draining would lose signals the chat asked to defer.
-    if let Some(cid) = chat_id {
-        if crate::services::tg_chat_config::is_quiet_now(state.db.pool(), cid).await {
-            info!("digest tick: chat {} is in quiet window, skipping", cid);
-            return;
-        }
-    }
-
     let drained = state.alert_bus.drain().await;
     if drained.is_empty() {
         info!("digest tick: bus empty, skipping send");
         return;
     }
 
-    // Honor subscribed_kinds for the destination chat. An empty/absent list
-    // means "all kinds", so existing rows keep today's behavior.
-    let filtered: Vec<Signal> = if let Some(cid) = chat_id {
-        let pool = state.db.pool();
-        let mut kept = Vec::with_capacity(drained.len());
-        for s in drained {
-            if crate::services::tg_chat_config::is_kind_subscribed(pool, cid, s.kind.as_str())
-                .await
-            {
-                kept.push(s);
-            }
-        }
-        kept
-    } else {
-        drained
-    };
-
-    if filtered.is_empty() {
-        info!("digest tick: all signals filtered by subscribed_kinds, skipping send");
+    let pool = state.db.pool();
+    let destinations = collect_destinations(pool, env_chat_id).await;
+    if destinations.is_empty() {
+        warn!(
+            "digest tick: no destination chats (env chat unset and no tg_chat_config rows); \
+             {} signals dropped",
+            drained.len()
+        );
         return;
     }
 
     let now = now_secs();
-    let selected = select_top_signals(filtered, top_n, cooldown_secs, now, last_alerted);
-    if selected.is_empty() {
-        info!("digest tick: all candidates filtered by cooldown, skipping send");
-        return;
-    }
+    for chat_id in destinations {
+        // Quiet windows are per-chat — skipping a quiet chat must not affect
+        // any other chat's delivery in the same tick.
+        if crate::services::tg_chat_config::is_quiet_now(pool, chat_id).await {
+            info!("digest tick: chat {} is in quiet window, skipping", chat_id);
+            continue;
+        }
 
-    for s in &selected {
-        last_alerted.insert(s.dedup_key(), now);
-    }
+        let threshold =
+            crate::services::tg_chat_config::effective_threshold_for_chat(pool, chat_id, env_threshold)
+                .await;
 
-    let text = format_digest(&selected);
-    if let Err(e) = tg.send(&text).await {
-        warn!("digest send failed: {}", e);
-    } else {
-        info!("digest sent ({} signals)", selected.len());
+        let mut filtered: Vec<Signal> = Vec::with_capacity(drained.len());
+        for s in &drained {
+            if !chat_accepts_signal(pool, chat_id, s, threshold).await {
+                continue;
+            }
+            filtered.push(s.clone());
+        }
+        if filtered.is_empty() {
+            info!("digest tick: chat {} filtered out everything, skipping", chat_id);
+            continue;
+        }
+
+        let chat_cooldowns = scoped_cooldowns(last_alerted, chat_id);
+        let selected = select_top_signals(filtered, top_n, cooldown_secs, now, &chat_cooldowns);
+        if selected.is_empty() {
+            info!(
+                "digest tick: chat {} candidates all in cooldown, skipping",
+                chat_id
+            );
+            continue;
+        }
+
+        for s in &selected {
+            last_alerted.insert((chat_id, s.dedup_key()), now);
+        }
+
+        let text = format_digest(&selected);
+        if let Err(e) = tg.send_to(chat_id, &text).await {
+            warn!("digest send failed for chat {}: {}", chat_id, e);
+        } else {
+            info!("digest sent to chat {} ({} signals)", chat_id, selected.len());
+        }
     }
+}
+
+/// Resolve the set of destination chats for a tick: the env-configured chat
+/// (if any) plus every row in `tg_chat_config`. Deduplicated, deterministic
+/// order (env chat first, then config-table chats sorted ascending).
+async fn collect_destinations(
+    pool: &sqlx::PgPool,
+    env_chat_id: Option<i64>,
+) -> Vec<i64> {
+    let mut seen: HashSet<i64> = HashSet::new();
+    let mut out: Vec<i64> = Vec::new();
+    if let Some(cid) = env_chat_id {
+        if seen.insert(cid) {
+            out.push(cid);
+        }
+    }
+    let mut config_chats = crate::services::tg_chat_config::list_chat_ids(pool).await;
+    config_chats.sort();
+    for cid in config_chats {
+        if seen.insert(cid) {
+            out.push(cid);
+        }
+    }
+    out
+}
+
+/// Apply the per-chat filter pipeline to a single signal: subscribed kinds,
+/// muted markets (slug + market_key), and per-chat threshold (signal move size
+/// must clear the chat's threshold, else it's noise to that chat).
+async fn chat_accepts_signal(
+    pool: &sqlx::PgPool,
+    chat_id: i64,
+    signal: &Signal,
+    threshold_pct: f64,
+) -> bool {
+    if signal.move_size.abs() < threshold_pct {
+        return false;
+    }
+    if !crate::services::tg_chat_config::is_kind_subscribed(pool, chat_id, signal.kind.as_str())
+        .await
+    {
+        return false;
+    }
+    if let Some(slug) = &signal.slug {
+        if crate::services::tg_chat_config::is_market_muted(pool, chat_id, slug).await {
+            return false;
+        }
+    }
+    if crate::services::tg_chat_config::is_market_muted(pool, chat_id, &signal.market_key).await {
+        return false;
+    }
+    true
+}
+
+/// Project the per-chat slice of the global `(chat_id, dedup_key) -> ts` map
+/// down to the `dedup_key -> ts` shape `select_top_signals` already takes.
+fn scoped_cooldowns(
+    all: &HashMap<(i64, String), u64>,
+    chat_id: i64,
+) -> HashMap<String, u64> {
+    all.iter()
+        .filter(|((cid, _), _)| *cid == chat_id)
+        .map(|((_, key), ts)| (key.clone(), *ts))
+        .collect()
 }
 
 /// Pick the highest-scoring signal per market, drop anything in cooldown, then
@@ -245,6 +324,14 @@ fn env_usize(key: &str, default: usize) -> usize {
     std::env::var(key)
         .ok()
         .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(default)
+}
+
+fn env_f64(key: &str, default: f64) -> f64 {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse::<f64>().ok())
+        .filter(|v| v.is_finite())
         .unwrap_or(default)
 }
 
@@ -367,5 +454,56 @@ mod tests {
     fn empty_input_returns_empty_selection() {
         let picked = select_top_signals(vec![], 3, 14_400, 1_000_000, &HashMap::new());
         assert!(picked.is_empty());
+    }
+
+    #[test]
+    fn scoped_cooldowns_returns_only_target_chat_entries() {
+        let mut all: HashMap<(i64, String), u64> = HashMap::new();
+        all.insert((100, "polymarket:m1".to_string()), 50);
+        all.insert((100, "polymarket:m2".to_string()), 60);
+        all.insert((200, "polymarket:m1".to_string()), 70);
+
+        let chat100 = scoped_cooldowns(&all, 100);
+        assert_eq!(chat100.len(), 2);
+        assert_eq!(chat100.get("polymarket:m1"), Some(&50));
+        assert_eq!(chat100.get("polymarket:m2"), Some(&60));
+
+        let chat200 = scoped_cooldowns(&all, 200);
+        assert_eq!(chat200.len(), 1);
+        assert_eq!(chat200.get("polymarket:m1"), Some(&70));
+
+        let chat999 = scoped_cooldowns(&all, 999);
+        assert!(chat999.is_empty());
+    }
+
+    #[test]
+    fn per_chat_cooldowns_isolate_chats() {
+        // Chat 100 was just alerted about m1 — cooldown active for chat 100.
+        // Chat 200 has no cooldown for m1 — should still see it.
+        let now = 1_000_000;
+        let mut all: HashMap<(i64, String), u64> = HashMap::new();
+        all.insert((100, "polymarket:m1".to_string()), now - 600);
+        let signals = vec![mk("polymarket", "m1", Some(50_000.0), 10.0, now)];
+
+        let chat100 = scoped_cooldowns(&all, 100);
+        let picked100 = select_top_signals(signals.clone(), 3, 14_400, now, &chat100);
+        assert!(picked100.is_empty(), "chat 100 should be in cooldown");
+
+        let chat200 = scoped_cooldowns(&all, 200);
+        let picked200 = select_top_signals(signals, 3, 14_400, now, &chat200);
+        assert_eq!(picked200.len(), 1);
+        assert_eq!(picked200[0].market_key, "m1");
+    }
+
+    #[test]
+    fn move_size_below_chat_threshold_drops_signal() {
+        // chat_accepts_signal is async + DB-bound; the threshold portion is the
+        // simplest pure check on the signal itself.
+        let now = 1_000_000;
+        let small = mk("polymarket", "m1", Some(50_000.0), 3.0, now);
+        let big = mk("polymarket", "m2", Some(50_000.0), 10.0, now);
+        // Threshold 5 → small (3) drops, big (10) stays.
+        assert!(small.move_size.abs() < 5.0);
+        assert!(big.move_size.abs() >= 5.0);
     }
 }

--- a/app/src/services/telegram_commands.rs
+++ b/app/src/services/telegram_commands.rs
@@ -197,10 +197,16 @@ async fn handle_message(
         "verify" => verify_text(state, msg.chat.id, nonces, parsed.args.as_deref()).await,
         "unlink" => unlink_text(state, msg.chat.id).await,
         _ => {
-            // In groups other bots own commands like `/setup_raid` — stay
-            // silent so we don't spam "unknown command". DMs are 1:1 so the
-            // hint is still useful there.
+            // Groups: stay silent — third-party bots own commands like
+            // /setup_raid and we don't want to spam "unknown command".
             if !is_dm {
+                return;
+            }
+            // DMs: only reply when the command plausibly belongs to us.
+            // Skip the well-known third-party command vocabulary (raid bots,
+            // volume bots, sniper bots) and anything that doesn't look like
+            // a typo of one of our short alphabetic commands.
+            if is_third_party_command(&parsed.name) || !looks_like_our_command(&parsed.name) {
                 return;
             }
             format!("unknown command /{}. try /help", html_escape(&parsed.name))
@@ -230,6 +236,87 @@ fn parse_command(text: &str) -> Option<ParsedCommand> {
         return None;
     }
     Some(ParsedCommand { name, args })
+}
+
+/// Vocabulary owned by other Telegram bots that frequently show up in the same
+/// chats as the relay44 bot — raid coordinators, sniper bots, volume bots,
+/// generic group-engagement bots. We never reply with "unknown command" to
+/// any of these, regardless of chat type. Lowercase, no leading slash.
+const THIRD_PARTY_COMMANDS: &[&str] = &[
+    // Raid / engagement bots.
+    "raid",
+    "raids",
+    "raidstart",
+    "raidend",
+    "setup_raid",
+    "setupraid",
+    "newraid",
+    "checkraid",
+    "endraid",
+    "leaderboard",
+    "leaderboards",
+    "tweet",
+    "tweets",
+    "retweet",
+    "like",
+    "comment",
+    "shill",
+    "engage",
+    "engagement",
+    "task",
+    "tasks",
+    "claim",
+    // Sniper / trading bots that share command surface area.
+    "snipe",
+    "swap",
+    "send",
+    "transfer",
+    "approve",
+    "withdraw",
+    "deposit",
+    "limit",
+    "long",
+    "short",
+    "pnl",
+    "balance",
+    "wallet",
+    "wallets",
+    "portfolio",
+    // Generic group-mod / chat bots.
+    "ban",
+    "kick",
+    "mute_user",
+    "warn",
+    "rules",
+    "captcha",
+    "welcome",
+    "pin",
+    "unpin",
+    "report",
+    // Common chat slang sometimes typed with a leading slash.
+    "gm",
+    "gn",
+    "lfg",
+    "wagmi",
+    "ngmi",
+    "wen",
+    "ca",
+];
+
+fn is_third_party_command(name: &str) -> bool {
+    THIRD_PARTY_COMMANDS.contains(&name)
+}
+
+/// Heuristic for "this could be a typo of one of our commands and a hint is
+/// useful." Our entire command surface is purely-alphabetic ASCII, between 3
+/// and 11 chars. Anything outside that shape (digits, underscores, very long
+/// names, single letters) belongs to another bot or is junk and stays silent.
+fn looks_like_our_command(name: &str) -> bool {
+    let len = name.len();
+    if !(2..=12).contains(&len) {
+        return false;
+    }
+    name.chars().all(|c| c.is_ascii_alphabetic())
 }
 
 fn help_text() -> String {
@@ -922,6 +1009,83 @@ mod tests {
         assert!(parse_command("hello").is_none());
         assert!(parse_command("").is_none());
         assert!(parse_command("/").is_none());
+    }
+
+    #[test]
+    fn third_party_raid_commands_are_silenced() {
+        for cmd in [
+            "raid",
+            "setup_raid",
+            "setupraid",
+            "raidstart",
+            "leaderboard",
+            "tweet",
+            "shill",
+        ] {
+            assert!(
+                is_third_party_command(cmd),
+                "raid-vocabulary command {cmd} should be silenced"
+            );
+        }
+    }
+
+    #[test]
+    fn third_party_sniper_and_chat_commands_are_silenced() {
+        for cmd in ["snipe", "swap", "ban", "captcha", "gm", "lfg"] {
+            assert!(
+                is_third_party_command(cmd),
+                "third-party command {cmd} should be silenced"
+            );
+        }
+    }
+
+    #[test]
+    fn our_commands_are_not_in_third_party_list() {
+        for cmd in [
+            "start",
+            "help",
+            "status",
+            "top",
+            "market",
+            "config",
+            "mute",
+            "unmute",
+            "threshold",
+            "cooldown",
+            "quiet",
+            "unquiet",
+            "subscribe",
+            "unsubscribe",
+            "digest",
+            "quote",
+            "link",
+            "verify",
+            "unlink",
+        ] {
+            assert!(
+                !is_third_party_command(cmd),
+                "{cmd} is one of our commands, must not be in the third-party list"
+            );
+        }
+    }
+
+    #[test]
+    fn typo_heuristic_matches_short_alphabetic_commands() {
+        // Typos of our actual commands should still get a hint.
+        assert!(looks_like_our_command("statu"));
+        assert!(looks_like_our_command("hlep"));
+        assert!(looks_like_our_command("config"));
+        assert!(looks_like_our_command("toop"));
+    }
+
+    #[test]
+    fn typo_heuristic_rejects_third_party_shapes() {
+        // Underscores, digits, very long, very short → not a typo of ours.
+        assert!(!looks_like_our_command("setup_raid"));
+        assert!(!looks_like_our_command("raid123"));
+        assert!(!looks_like_our_command("a"));
+        assert!(!looks_like_our_command("supercalifragilistic"));
+        assert!(!looks_like_our_command(""));
     }
 
     #[test]

--- a/app/src/services/telegram_commands.rs
+++ b/app/src/services/telegram_commands.rs
@@ -68,7 +68,7 @@ pub fn spawn(state: Arc<AppState>) {
         }
     };
     let client = TelegramClient { bot_token, http };
-    let nonces: NonceStore = Arc::new(Mutex::new(HashMap::new()));
+    let nonces = Arc::new(NonceStore::new());
     info!("Starting Telegram command handler");
 
     tokio::spawn(async move {
@@ -100,49 +100,121 @@ pub fn spawn(state: Arc<AppState>) {
     });
 }
 
-/// In-memory store for outstanding `/link` nonces, keyed by
-/// `(chat_id, wallet_lower)`. Entries expire after `NONCE_TTL_SECS`.
+/// Stores the outstanding `/link` nonce for each chat. Redis is the primary
+/// backing store with TTL, so a single API restart no longer invalidates
+/// every in-flight `/link`. An in-memory map shadows Redis as a fallback for
+/// the (rare) case of Redis being unavailable mid-flow — `/link` still works,
+/// just without persistence. Latest `/link` per chat wins.
 ///
-/// Deliberately not persisted: on restart the user simply re-issues
-/// `/link`. Keeps the surface small and avoids granting nonce visibility
-/// to anyone with DB read access.
-type NonceStore = Arc<Mutex<HashMap<(i64, String), PendingNonce>>>;
+/// Single-use semantics live at the consume step: `peek` is non-destructive
+/// so the caller can verify a signature first, then `consume` to invalidate.
+struct NonceStore {
+    fallback: Mutex<HashMap<i64, PendingNonce>>,
+}
 
+#[derive(Clone)]
 struct PendingNonce {
+    wallet: String,
     nonce: String,
     created_at: Instant,
 }
 
-fn put_nonce(store: &NonceStore, chat_id: i64, wallet_lower: &str, nonce: String) {
-    let mut guard = store.lock().expect("nonce store poisoned");
-    purge_expired(&mut guard);
-    guard.insert(
-        (chat_id, wallet_lower.to_string()),
-        PendingNonce {
-            nonce,
-            created_at: Instant::now(),
-        },
-    );
+const NONCE_REDIS_PREFIX: &str = "tg:link_pending";
+
+fn nonce_key(chat_id: i64) -> String {
+    format!("{}:{}", NONCE_REDIS_PREFIX, chat_id)
 }
 
-fn take_nonce(store: &NonceStore, chat_id: i64, wallet_lower: &str) -> Option<String> {
-    let mut guard = store.lock().expect("nonce store poisoned");
-    purge_expired(&mut guard);
-    guard
-        .remove(&(chat_id, wallet_lower.to_string()))
-        .map(|p| p.nonce)
+impl NonceStore {
+    fn new() -> Self {
+        Self {
+            fallback: Mutex::new(HashMap::new()),
+        }
+    }
+
+    async fn put(
+        &self,
+        redis: &super::redis::RedisService,
+        chat_id: i64,
+        wallet_lower: &str,
+        nonce: &str,
+    ) {
+        let value = serde_json::json!({
+            "wallet": wallet_lower,
+            "nonce": nonce,
+        });
+        match redis.set(&nonce_key(chat_id), &value, Some(NONCE_TTL_SECS)).await {
+            Ok(()) => {}
+            Err(e) => {
+                warn!(
+                    "nonce store: redis put failed, using in-memory fallback: {}",
+                    e
+                );
+                self.put_in_memory(chat_id, wallet_lower, nonce);
+            }
+        }
+    }
+
+    async fn peek(
+        &self,
+        redis: &super::redis::RedisService,
+        chat_id: i64,
+    ) -> Option<(String, String)> {
+        match redis.get::<serde_json::Value>(&nonce_key(chat_id)).await {
+            Ok(Some(v)) => {
+                let wallet = v.get("wallet").and_then(|w| w.as_str())?;
+                let nonce = v.get("nonce").and_then(|n| n.as_str())?;
+                Some((wallet.to_string(), nonce.to_string()))
+            }
+            Ok(None) => self.peek_in_memory(chat_id),
+            Err(e) => {
+                warn!(
+                    "nonce store: redis peek failed, falling back to memory: {}",
+                    e
+                );
+                self.peek_in_memory(chat_id)
+            }
+        }
+    }
+
+    async fn consume(&self, redis: &super::redis::RedisService, chat_id: i64) {
+        if let Err(e) = redis.delete(&nonce_key(chat_id)).await {
+            warn!("nonce store: redis delete failed: {}", e);
+        }
+        // Always purge the in-memory shadow regardless of which path served
+        // the value — single-use must hold across both stores.
+        self.consume_in_memory(chat_id);
+    }
+
+    fn put_in_memory(&self, chat_id: i64, wallet_lower: &str, nonce: &str) {
+        let mut guard = self.fallback.lock().expect("nonce store poisoned");
+        purge_expired_in_memory(&mut guard);
+        guard.insert(
+            chat_id,
+            PendingNonce {
+                wallet: wallet_lower.to_string(),
+                nonce: nonce.to_string(),
+                created_at: Instant::now(),
+            },
+        );
+    }
+
+    fn peek_in_memory(&self, chat_id: i64) -> Option<(String, String)> {
+        let mut guard = self.fallback.lock().expect("nonce store poisoned");
+        purge_expired_in_memory(&mut guard);
+        guard
+            .get(&chat_id)
+            .map(|p| (p.wallet.clone(), p.nonce.clone()))
+    }
+
+    fn consume_in_memory(&self, chat_id: i64) {
+        let mut guard = self.fallback.lock().expect("nonce store poisoned");
+        purge_expired_in_memory(&mut guard);
+        guard.remove(&chat_id);
+    }
 }
 
-fn find_nonce_for_chat(store: &NonceStore, chat_id: i64) -> Option<(String, String)> {
-    let mut guard = store.lock().expect("nonce store poisoned");
-    purge_expired(&mut guard);
-    guard
-        .iter()
-        .find(|((cid, _), _)| *cid == chat_id)
-        .map(|((_, wallet), p)| (wallet.clone(), p.nonce.clone()))
-}
-
-fn purge_expired(map: &mut HashMap<(i64, String), PendingNonce>) {
+fn purge_expired_in_memory(map: &mut HashMap<i64, PendingNonce>) {
     let ttl = Duration::from_secs(NONCE_TTL_SECS);
     map.retain(|_, v| v.created_at.elapsed() < ttl);
 }
@@ -158,7 +230,7 @@ async fn handle_message(
     client: &TelegramClient,
     allowed_chat_id: Option<i64>,
     dm_enabled: bool,
-    nonces: &NonceStore,
+    nonces: &Arc<NonceStore>,
     msg: &Message,
 ) {
     let is_group_match = Some(msg.chat.id) == allowed_chat_id;
@@ -193,7 +265,7 @@ async fn handle_message(
         "digest" => digest_text(state).await,
         "quote" => quote_text(state, is_dm, parsed.args.as_deref()).await,
         "config" => config_text(state, msg.chat.id).await,
-        "link" => link_text(msg.chat.id, nonces, parsed.args.as_deref()),
+        "link" => link_text(state, msg.chat.id, nonces, parsed.args.as_deref()).await,
         "verify" => verify_text(state, msg.chat.id, nonces, parsed.args.as_deref()).await,
         "unlink" => unlink_text(state, msg.chat.id).await,
         _ => {
@@ -742,7 +814,12 @@ async fn config_text(state: &AppState, chat_id: i64) -> String {
     out.join("\n")
 }
 
-fn link_text(chat_id: i64, nonces: &NonceStore, args: Option<&str>) -> String {
+async fn link_text(
+    state: &AppState,
+    chat_id: i64,
+    nonces: &Arc<NonceStore>,
+    args: Option<&str>,
+) -> String {
     let raw = match args.and_then(|s| s.split_whitespace().next()) {
         Some(s) => s.to_string(),
         None => return "usage: /link &lt;0x…&gt;".to_string(),
@@ -753,7 +830,7 @@ fn link_text(chat_id: i64, nonces: &NonceStore, args: Option<&str>) -> String {
     };
     let nonce = fresh_nonce();
     let message = tg_chat_config::link_message(chat_id, &wallet_lower, &nonce);
-    put_nonce(nonces, chat_id, &wallet_lower, nonce);
+    nonces.put(&state.redis, chat_id, &wallet_lower, &nonce).await;
     format!(
         "Sign this message with your wallet and send <code>/verify &lt;signature&gt;</code> within 10 min:\n\n<code>{}</code>\n\n<i>Read-only binding. No spending authority is granted.</i>",
         html_escape(&message)
@@ -763,14 +840,14 @@ fn link_text(chat_id: i64, nonces: &NonceStore, args: Option<&str>) -> String {
 async fn verify_text(
     state: &AppState,
     chat_id: i64,
-    nonces: &NonceStore,
+    nonces: &Arc<NonceStore>,
     args: Option<&str>,
 ) -> String {
     let signature = match args.and_then(|s| s.split_whitespace().next()) {
         Some(s) => s.to_string(),
         None => return "usage: /verify &lt;signature&gt;".to_string(),
     };
-    let (expected_wallet, nonce) = match find_nonce_for_chat(nonces, chat_id) {
+    let (expected_wallet, nonce) = match nonces.peek(&state.redis, chat_id).await {
         Some(pair) => pair,
         None => {
             return "no pending /link for this chat. run /link &lt;0x…&gt; first.".to_string();
@@ -786,7 +863,7 @@ async fn verify_text(
     }
 
     // Nonce is single-use; consume on success. Keeps replay closed.
-    let _ = take_nonce(nonces, chat_id, &expected_wallet);
+    nonces.consume(&state.redis, chat_id).await;
 
     // If the existing users table has a row for this wallet, we'd resolve an
     // id here. Today the table is keyed on a Solana-length `wallet` primary
@@ -1120,21 +1197,47 @@ mod tests {
     }
 
     #[test]
-    fn nonce_store_put_and_take_roundtrip() {
-        let store: NonceStore = Arc::new(Mutex::new(HashMap::new()));
-        put_nonce(&store, 7, "0xabc", "n1".to_string());
-        assert_eq!(take_nonce(&store, 7, "0xabc").as_deref(), Some("n1"));
-        // single-use: second take returns None.
-        assert!(take_nonce(&store, 7, "0xabc").is_none());
+    fn nonce_store_in_memory_roundtrip() {
+        let store = NonceStore::new();
+        store.put_in_memory(7, "0xabc", "n1");
+        let peeked = store.peek_in_memory(7);
+        assert_eq!(
+            peeked.as_ref().map(|(w, n)| (w.as_str(), n.as_str())),
+            Some(("0xabc", "n1"))
+        );
+        // peek is non-destructive.
+        assert!(store.peek_in_memory(7).is_some());
+        // consume invalidates.
+        store.consume_in_memory(7);
+        assert!(store.peek_in_memory(7).is_none());
     }
 
     #[test]
-    fn nonce_store_find_returns_latest_for_chat() {
-        let store: NonceStore = Arc::new(Mutex::new(HashMap::new()));
-        put_nonce(&store, 7, "0xabc", "n1".to_string());
-        let found = find_nonce_for_chat(&store, 7);
-        assert_eq!(found.as_ref().map(|(w, n)| (w.as_str(), n.as_str())), Some(("0xabc", "n1")));
-        assert!(find_nonce_for_chat(&store, 99).is_none());
+    fn nonce_store_in_memory_returns_none_for_unknown_chat() {
+        let store = NonceStore::new();
+        store.put_in_memory(7, "0xabc", "n1");
+        assert!(store.peek_in_memory(99).is_none());
+    }
+
+    #[test]
+    fn nonce_store_latest_link_overwrites_previous() {
+        // Simulates a user re-running /link with a different wallet in the same
+        // chat. We keep latest-wins semantics so the new /link is what
+        // /verify will check against.
+        let store = NonceStore::new();
+        store.put_in_memory(7, "0xaaa", "first-nonce");
+        store.put_in_memory(7, "0xbbb", "second-nonce");
+        let peeked = store.peek_in_memory(7).unwrap();
+        assert_eq!(peeked.0, "0xbbb");
+        assert_eq!(peeked.1, "second-nonce");
+    }
+
+    #[test]
+    fn nonce_redis_key_includes_chat_id_under_link_pending_prefix() {
+        // Keys live under tg:link_pending:* so an ops engineer can easily list
+        // outstanding /link flows in production via Redis SCAN.
+        assert_eq!(nonce_key(123), "tg:link_pending:123");
+        assert_eq!(nonce_key(-1003504563338), "tg:link_pending:-1003504563338");
     }
 
     #[test]

--- a/app/src/services/telegram_commands.rs
+++ b/app/src/services/telegram_commands.rs
@@ -951,25 +951,18 @@ impl TelegramClient {
             reply_to_message_id: Option<i64>,
         }
         let url = format!("https://api.telegram.org/bot{}/sendMessage", self.bot_token);
-        let resp = self
-            .http
-            .post(&url)
-            .json(&Req {
-                chat_id,
-                text,
-                parse_mode: "HTML",
-                disable_web_page_preview: true,
-                reply_to_message_id: reply_to,
-            })
-            .send()
-            .await
-            .map_err(|e| format!("request: {}", e))?;
-        if !resp.status().is_success() {
-            let code = resp.status();
-            let body = resp.text().await.unwrap_or_default();
-            return Err(format!("telegram {}: {}", code, body));
-        }
-        Ok(())
+        let payload = Req {
+            chat_id,
+            text,
+            parse_mode: "HTML",
+            disable_web_page_preview: true,
+            reply_to_message_id: reply_to,
+        };
+        super::telegram_format::send_with_retry("sendMessage", || {
+            self.http.post(&url).json(&payload).send()
+        })
+        .await
+        .map(|_| ())
     }
 }
 

--- a/app/src/services/telegram_format.rs
+++ b/app/src/services/telegram_format.rs
@@ -18,9 +18,15 @@
 //! `TelegramClient` is the shared HTTP client. It posts with
 //! `parse_mode: "HTML"` and `disable_web_page_preview: true`.
 
+use std::future::Future;
 use std::time::Duration;
 
+use log::warn;
 use serde::Serialize;
+use tokio::time::sleep;
+
+const MAX_RETRY_ATTEMPTS: u32 = 5;
+const MAX_RETRY_DELAY_SECS: u64 = 60;
 
 /// HTML-escapes a user-derived string for safe embedding in a Telegram HTML
 /// message. Covers the characters Telegram's HTML parser requires (`<`, `>`,
@@ -165,25 +171,117 @@ impl TelegramClient {
             disable_web_page_preview: bool,
         }
         let url = format!("https://api.telegram.org/bot{}/sendMessage", self.bot_token);
-        let resp = self
-            .http
-            .post(&url)
-            .json(&Payload {
-                chat_id: &self.chat_id,
-                text,
-                parse_mode: "HTML",
-                disable_web_page_preview: true,
-            })
-            .send()
+        let payload = Payload {
+            chat_id: &self.chat_id,
+            text,
+            parse_mode: "HTML",
+            disable_web_page_preview: true,
+        };
+        send_with_retry("sendMessage", || self.http.post(&url).json(&payload).send())
             .await
-            .map_err(|e| format!("request: {}", e))?;
-        if !resp.status().is_success() {
-            let code = resp.status();
-            let body = resp.text().await.unwrap_or_default();
-            return Err(format!("telegram {}: {}", code, body));
-        }
-        Ok(())
+            .map(|_| ())
     }
+}
+
+/// Outcome of inspecting a Telegram API response: either a success body or a
+/// classified failure (permanent vs. retryable, with optional `retry_after`).
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum RetryOutcome {
+    Success,
+    Permanent(String),
+    Retryable {
+        message: String,
+        delay_hint: Option<u64>,
+    },
+}
+
+/// Pure classifier for a Telegram API response. Body bytes are passed in so
+/// this is testable without a live HTTP call. Telegram returns
+/// `{"ok": false, "error_code": 429, "parameters": {"retry_after": N}}` on
+/// rate-limits; we honour that hint when present.
+pub(crate) fn classify_response(status: u16, body: &[u8]) -> RetryOutcome {
+    if (200..300).contains(&status) {
+        return RetryOutcome::Success;
+    }
+    let snippet = String::from_utf8_lossy(body).chars().take(256).collect::<String>();
+    if status == 429 {
+        return RetryOutcome::Retryable {
+            message: format!("429 {snippet}"),
+            delay_hint: parse_retry_after(body),
+        };
+    }
+    if (500..600).contains(&status) {
+        return RetryOutcome::Retryable {
+            message: format!("{status} {snippet}"),
+            delay_hint: None,
+        };
+    }
+    RetryOutcome::Permanent(format!("{status} {snippet}"))
+}
+
+fn parse_retry_after(body: &[u8]) -> Option<u64> {
+    let value: serde_json::Value = serde_json::from_slice(body).ok()?;
+    value.get("parameters")?.get("retry_after")?.as_u64()
+}
+
+/// Bounded exponential backoff: 1s, 2s, 4s, 8s, 16s, capped at 60s.
+pub(crate) fn backoff_secs(attempt: u32) -> u64 {
+    let shift = attempt.saturating_sub(1).min(6);
+    (1u64 << shift).min(MAX_RETRY_DELAY_SECS)
+}
+
+/// Issue a request via the supplied builder and apply Telegram-aware retries.
+/// `make_request` is invoked on each attempt so it can produce a fresh future.
+/// Returns the response body bytes (with the final status) or the last
+/// classified error after retries are exhausted.
+pub(crate) async fn send_with_retry<F, Fut>(
+    label: &str,
+    mut make_request: F,
+) -> Result<Vec<u8>, String>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = reqwest::Result<reqwest::Response>>,
+{
+    let mut last_error: String = String::new();
+    for attempt in 1..=MAX_RETRY_ATTEMPTS {
+        match make_request().await {
+            Ok(resp) => {
+                let status = resp.status().as_u16();
+                let bytes = resp.bytes().await.unwrap_or_default();
+                match classify_response(status, &bytes) {
+                    RetryOutcome::Success => {
+                        return Ok(bytes.to_vec());
+                    }
+                    RetryOutcome::Permanent(msg) => {
+                        return Err(format!("{label}: {msg}"));
+                    }
+                    RetryOutcome::Retryable { message, delay_hint } => {
+                        last_error = format!("{label}: {message}");
+                        if attempt < MAX_RETRY_ATTEMPTS {
+                            let wait = delay_hint
+                                .unwrap_or_else(|| backoff_secs(attempt))
+                                .min(MAX_RETRY_DELAY_SECS);
+                            warn!(
+                                "{label} attempt {attempt} failed; retrying in {wait}s ({message})"
+                            );
+                            sleep(Duration::from_secs(wait)).await;
+                            continue;
+                        }
+                    }
+                }
+            }
+            Err(err) => {
+                last_error = format!("{label}: request {err}");
+                if attempt < MAX_RETRY_ATTEMPTS {
+                    let wait = backoff_secs(attempt);
+                    warn!("{label} attempt {attempt} request error; retrying in {wait}s ({err})");
+                    sleep(Duration::from_secs(wait)).await;
+                    continue;
+                }
+            }
+        }
+    }
+    Err(format!("retries exhausted: {last_error}"))
 }
 
 #[cfg(test)]
@@ -290,5 +388,67 @@ mod tests {
         assert_eq!(venue_title("polymarket"), "Polymarket");
         assert_eq!(venue_title("limitless"), "Limitless");
         assert_eq!(venue_title("nope"), "Unknown");
+    }
+
+    #[test]
+    fn classify_response_treats_2xx_as_success() {
+        assert_eq!(classify_response(200, b"{}"), RetryOutcome::Success);
+        assert_eq!(classify_response(204, b""), RetryOutcome::Success);
+    }
+
+    #[test]
+    fn classify_response_429_extracts_retry_after_when_present() {
+        let body = br#"{"ok":false,"error_code":429,"description":"Too Many Requests","parameters":{"retry_after":12}}"#;
+        match classify_response(429, body) {
+            RetryOutcome::Retryable { delay_hint, .. } => {
+                assert_eq!(delay_hint, Some(12));
+            }
+            other => panic!("expected Retryable with delay_hint, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_response_429_without_retry_after_falls_back() {
+        let body = br#"{"ok":false,"error_code":429}"#;
+        match classify_response(429, body) {
+            RetryOutcome::Retryable { delay_hint, .. } => {
+                assert_eq!(delay_hint, None);
+            }
+            other => panic!("expected Retryable with no delay_hint, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_response_5xx_is_retryable() {
+        for status in [500_u16, 502, 503, 504] {
+            assert!(matches!(
+                classify_response(status, b"oops"),
+                RetryOutcome::Retryable { .. }
+            ));
+        }
+    }
+
+    #[test]
+    fn classify_response_4xx_other_than_429_is_permanent() {
+        // 400/401/403/404 — Telegram says no, no point retrying.
+        for status in [400_u16, 401, 403, 404] {
+            assert!(matches!(
+                classify_response(status, b"bad request"),
+                RetryOutcome::Permanent(_)
+            ));
+        }
+    }
+
+    #[test]
+    fn backoff_secs_is_bounded_exponential() {
+        assert_eq!(backoff_secs(1), 1);
+        assert_eq!(backoff_secs(2), 2);
+        assert_eq!(backoff_secs(3), 4);
+        assert_eq!(backoff_secs(4), 8);
+        assert_eq!(backoff_secs(5), 16);
+        assert_eq!(backoff_secs(6), 32);
+        // Cap kicks in past the 60s ceiling.
+        assert_eq!(backoff_secs(7), MAX_RETRY_DELAY_SECS);
+        assert_eq!(backoff_secs(20), MAX_RETRY_DELAY_SECS);
     }
 }

--- a/app/src/services/telegram_format.rs
+++ b/app/src/services/telegram_format.rs
@@ -163,6 +163,18 @@ impl TelegramClient {
     }
 
     pub async fn send(&self, text: &str) -> Result<(), String> {
+        self.send_raw(&self.chat_id, text).await
+    }
+
+    /// Send to an arbitrary chat id, ignoring the client's configured default.
+    /// Used by the digest scheduler when it fans a single drained-bus payload
+    /// out to multiple subscribed chats with per-chat filters applied.
+    pub async fn send_to(&self, chat_id: i64, text: &str) -> Result<(), String> {
+        let cid = chat_id.to_string();
+        self.send_raw(&cid, text).await
+    }
+
+    async fn send_raw(&self, chat_id: &str, text: &str) -> Result<(), String> {
         #[derive(Serialize)]
         struct Payload<'a> {
             chat_id: &'a str,
@@ -172,7 +184,7 @@ impl TelegramClient {
         }
         let url = format!("https://api.telegram.org/bot{}/sendMessage", self.bot_token);
         let payload = Payload {
-            chat_id: &self.chat_id,
+            chat_id,
             text,
             parse_mode: "HTML",
             disable_web_page_preview: true,

--- a/app/src/services/tg_chat_config.rs
+++ b/app/src/services/tg_chat_config.rs
@@ -354,6 +354,21 @@ pub async fn clear_linked_wallet(pool: &PgPool, chat_id: i64) -> Result<(), sqlx
     .map(|_| ())
 }
 
+/// Return every chat id that has a `tg_chat_config` row. Used by the digest
+/// scheduler to fan out per-chat filtered messages on each tick. Returns an
+/// empty vec on DB error so the digest still posts to the env-default chat.
+pub async fn list_chat_ids(pool: &PgPool) -> Vec<i64> {
+    let rows: Result<Vec<(i64,)>, sqlx::Error> =
+        sqlx::query_as("SELECT chat_id FROM tg_chat_config").fetch_all(pool).await;
+    match rows {
+        Ok(rows) => rows.into_iter().map(|(id,)| id).collect(),
+        Err(err) => {
+            log::warn!("tg_chat_config: list_chat_ids failed: {}", err);
+            Vec::new()
+        }
+    }
+}
+
 /// Resolve the effective threshold for `chat_id`, falling back to `env_default`
 /// when no override is set. Always returns a clamped value.
 pub async fn effective_threshold_for_chat(


### PR DESCRIPTION
## Summary

Four telegram-bot reliability fixes, stacked on the same branch because
each builds on the previous (multi-chat needs the retry layer's
\`send_to\`; persistent nonces use the same Redis path the rest of the
service already depends on).

### 1. Silence third-party raid/sniper commands in DMs (\`9d294a8\`)

PR #127 stopped \"unknown command\" replies from going to other bots and
from groups, but DMs still hit the hint when a user types a third-party
command like \`/raid\` or \`/setup_raid\` themselves.

- New \`THIRD_PARTY_COMMANDS\` allowlist (raid bots, sniper bots,
  chat-mod bots, common slash-prefixed slang) — silenced regardless of
  chat type.
- New \`looks_like_our_command\` heuristic — only replies with a hint
  when the unrecognized command is purely alphabetic ASCII between 2
  and 12 chars (the shape of every command we own). \`/setup_raid\`,
  \`/raid123\`, single letters all fall through silently.

### 2. Retry sends on 429 and transient 5xx (\`88b17c8\`)

Both telegram clients used to log and drop any non-2xx response. Digest
signals were silently lost on rate-limit; command replies vanished on
transient 5xx.

- Shared \`send_with_retry\` helper in \`telegram_format\`, used by both
  the alerter-side \`TelegramClient\` and the polling-side client in
  \`telegram_commands\`.
- Honours Telegram's \`parameters.retry_after\` on 429.
- Bounded exponential backoff (1s, 2s, 4s, 8s, 16s, capped at 60s) for
  5xx and network errors.
- 4xx other than 429 → permanent, no retry.
- Pure \`classify_response\` function for testability.

### 3. Fan the digest out per-chat (\`a0c6e36\`)

The digest scheduler used to drain the bus and post one message to the
env \`TELEGRAM_CHAT_ID\`. Per-chat overrides (\`/threshold\`, \`/mute\`,
\`/subscribe\`, \`/quiet\`) wrote rows into \`tg_chat_config\` but the
alerter ignored them — users were typing commands that did nothing.

- Resolves destinations as env chat ∪ all \`tg_chat_config\` rows.
- Per chat: applies quiet window, subscribed_kinds, muted_markets,
  effective_threshold.
- Per-chat cooldown via \`HashMap<(i64, String), u64>\` projected down
  to the existing \`select_top_signals\` shape — a market just sent to
  chat A doesn't suppress it for chat B.
- New \`TelegramClient::send_to(chat_id, ...)\` lets the digest target
  arbitrary chats without changing the existing \`send()\` surface that
  other alerters depend on.

### 4. Persist /link nonces in Redis (\`209bf92\`)

The \`/link\` nonce store was deliberately in-memory: a HashMap on the
long-poll task. Every API restart wiped it, forcing every user mid-flow
to redo \`/link\`. With auto-deploy from main that meant a fresh nonce
request after every merge.

- New \`NonceStore\` writes to Redis under \`tg:link_pending:<chat_id>\`
  with the configured \`NONCE_TTL_SECS\` as the key TTL.
- Single-use semantics: \`peek\` is non-destructive so signature
  verification can run first, then \`consume\` deletes.
- Redis hiccups fall back to an in-memory shadow map — \`/link\` keeps
  working through an outage, just without persistence.
- The chat-keyed scheme also fixes the previous non-deterministic
  HashMap-ordering behavior when multiple wallets had pending /link in
  the same chat. Latest \`/link\` wins.

## Test plan

- [x] \`cargo test -p relay44-backend --lib\` — **530 passed**, no failures
- [x] Telegram-area tests: 24 \`telegram_commands\` + 18 \`telegram_format\` + 12 \`digest_scheduler\` = **54 passed** (16 new across the four commits)
- [x] \`cargo clippy -p relay44-backend --lib -- -D warnings\` — clean
- [ ] After deploy: \`/raid\` in DM → no reply; \`/statu\` in DM → hint;
      \`/threshold 10\` in a non-env chat → next digest respects it;
      restart api, then \`/verify\` an outstanding link nonce → still works
      (nonce survived); digest survives a forced 429 from the bot api (manual)

## Notes

- Chats with no \`tg_chat_config\` row keep today's behavior — env
  threshold, no mutes, all kinds, no quiet window.
- The retry helper is invoked on every \`sendMessage\` call, so command
  replies and digest sends both benefit.
- Redis was already a hard dep; no new infrastructure.
- Out of scope: trade-from-DM execution, native \`/raid\` feature, the
  dormant direct-send paths in \`probability_alert\`/\`new_market_alert\`,
  digest idempotency under genuine retry-exhaust.