### PR TITLE
api: resolve settled polymarket markets in by-slug deep links

### DIFF
--- a/app/src/api/evm.rs
+++ b/app/src/api/evm.rs
@@ -3464,6 +3464,40 @@ pub async fn get_base_market(
     Ok(HttpResponse::Ok().json(market))
 }
 
+/// Single gamma `/markets` query for a slug, returning the numeric `id` of
+/// the first match if any. The `closed` flag mirrors gamma's filter so the
+/// caller can distinguish live vs. settled lookups.
+async fn fetch_polymarket_id_by_slug(
+    client: &reqwest::Client,
+    url: &str,
+    slug: &str,
+    closed: bool,
+) -> Result<Option<String>, ApiError> {
+    let closed_str = if closed { "true" } else { "false" };
+    let rows: Vec<serde_json::Value> = client
+        .get(url)
+        .query(&[
+            ("slug", slug),
+            ("limit", "1"),
+            ("closed", closed_str),
+        ])
+        .send()
+        .await
+        .map_err(|e| ApiError::bad_request("UPSTREAM_ERROR", &format!("gamma request: {}", e)))?
+        .error_for_status()
+        .map_err(|e| ApiError::bad_request("UPSTREAM_ERROR", &format!("gamma status: {}", e)))?
+        .json()
+        .await
+        .map_err(|e| ApiError::bad_request("UPSTREAM_ERROR", &format!("gamma parse: {}", e)))?;
+    Ok(rows.first().and_then(|r| {
+        r.get("id").and_then(|v| {
+            v.as_str()
+                .map(str::to_string)
+                .or_else(|| v.as_u64().map(|n| n.to_string()))
+        })
+    }))
+}
+
 pub async fn resolve_market_by_slug(
     state: web::Data<Arc<AppState>>,
     path: web::Path<(String, String)>,
@@ -3484,26 +3518,19 @@ pub async fn resolve_market_by_slug(
             } else {
                 let base = state.config.polymarket_gamma_api_base.trim_end_matches('/');
                 let url = format!("{}/markets", base);
-                let rows: Vec<serde_json::Value> = reqwest::Client::new()
-                    .get(&url)
-                    .query(&[("slug", slug.as_str()), ("limit", "1")])
-                    .send()
-                    .await
-                    .map_err(|e| ApiError::bad_request("UPSTREAM_ERROR", &format!("gamma request: {}", e)))?
-                    .error_for_status()
-                    .map_err(|e| ApiError::bad_request("UPSTREAM_ERROR", &format!("gamma status: {}", e)))?
-                    .json()
-                    .await
-                    .map_err(|e| ApiError::bad_request("UPSTREAM_ERROR", &format!("gamma parse: {}", e)))?;
-                let id = rows
-                    .first()
-                    .and_then(|r| r.get("id"))
-                    .and_then(|v| {
-                        v.as_str()
-                            .map(str::to_string)
-                            .or_else(|| v.as_u64().map(|n| n.to_string()))
-                    })
-                    .ok_or_else(|| ApiError::not_found("polymarket market"))?;
+                let client = reqwest::Client::new();
+
+                // Gamma defaults to active=true&closed=false. Live markets resolve
+                // on this first call. Settled (closed=true) markets — which is
+                // where most stale digest links point — need an explicit retry,
+                // because the slug field stays the same after settlement and we
+                // still want the canonical id so the markets/[id] page can render.
+                let mut id: Option<String> = fetch_polymarket_id_by_slug(&client, &url, &slug, false)
+                    .await?;
+                if id.is_none() {
+                    id = fetch_polymarket_id_by_slug(&client, &url, &slug, true).await?;
+                }
+                let id = id.ok_or_else(|| ApiError::not_found("polymarket market"))?;
                 let canonical = format!("polymarket:{}", id);
                 let _ = state.redis.set(&cache_key, &canonical, Some(3600)).await;
                 canonical


### PR DESCRIPTION
## Summary

Bot digest links to recently-settled markets returned 404 from
\`/v1/evm/markets/by-slug/polymarket/<slug>\` because gamma's \`/markets\`
endpoint defaults to \`closed=false&active=true\`. Today's example:
\`bra-flu-cha-2026-04-26-flu\` (Fluminense vs Chapecoense, settled
overnight) — gamma returns \`[]\` without \`closed=true\`, so our
resolver gave up.

Adds a small \`fetch_polymarket_id_by_slug\` helper and calls it twice
on miss: first with \`closed=false\` (live markets), then with
\`closed=true\` (settled markets). The numeric id stays the same after
settlement so the canonical id format (\`polymarket:<id>\`) is
unchanged and the \`/markets/[id]\` page renders normally with the
final outcome.

## Test plan

- [x] \`cargo build -p relay44-backend\` — clean
- [x] \`cargo clippy -p relay44-backend --lib -- -D warnings\` — clean
- [x] \`cargo test -p relay44-backend --lib api::evm\` — 45 passed
- [x] Manual: \`curl 'https://gamma-api.polymarket.com/markets?slug=bra-flu-cha-2026-04-26-flu&limit=1&closed=true'\` returns market id \`1795166\`
- [ ] After deploy: \`curl 'https://relay44-api.onrender.com/v1/evm/markets/by-slug/polymarket/bra-flu-cha-2026-04-26-flu'\` returns \`{"canonicalId":"polymarket:1795166"}\` instead of 404