### PR TITLE
api: deactivate scanned-market rows when upstream drops them

### DIFF
--- a/app/src/services/limitless_scanner.rs
+++ b/app/src/services/limitless_scanner.rs
@@ -165,6 +165,16 @@ async fn run_scan(state: &AppState) -> Result<(i32, i32, i32), String> {
     // Cross-venue matching against Polymarket.
     let venue_matches = match_cross_venue(state, &all_markets).await;
 
+    // Deactivate rows that disappeared from the active feed — Limitless
+    // settles markets and stops returning them, but the row's `active` flag
+    // would otherwise stay true forever. Skipping when the scan returned zero
+    // so an upstream outage does not deactivate everything.
+    if total_scanned > 0 {
+        if let Err(e) = deactivate_stale_limitless(state).await {
+            warn!("Limitless scanner: deactivate-stale failed: {}", e);
+        }
+    }
+
     record_scan_run(
         state,
         total_scanned,
@@ -176,6 +186,27 @@ async fn run_scan(state: &AppState) -> Result<(i32, i32, i32), String> {
     .await;
 
     Ok((indexed, opportunities, venue_matches))
+}
+
+/// Mark rows whose `last_scanned_at` is older than five missed ticks as
+/// inactive, mirroring the polymarket_scanner sweep. Reads downstream
+/// (volume_spike_alert, /top) filter `WHERE active = TRUE`, so settled
+/// markets stop appearing in alerts and listings the next tick after this
+/// runs.
+async fn deactivate_stale_limitless(state: &AppState) -> Result<u64, sqlx::Error> {
+    let result = sqlx::query(
+        "UPDATE limitless_scanned_markets \
+         SET active = false \
+         WHERE active = true \
+           AND last_scanned_at < NOW() - INTERVAL '5 minutes'",
+    )
+    .execute(state.db.pool())
+    .await?;
+    let rows = result.rows_affected();
+    if rows > 0 {
+        info!("Limitless scanner: deactivated {} stale rows", rows);
+    }
+    Ok(rows)
 }
 
 // ── Opportunity scoring ──

--- a/app/src/services/polymarket_scanner.rs
+++ b/app/src/services/polymarket_scanner.rs
@@ -556,6 +556,16 @@ pub async fn run_scan(state: &AppState) -> Result<Vec<ScannedOpportunity>, Strin
         }
     }
 
+    // Deactivate rows the scanner stopped seeing — Polymarket settles markets
+    // overnight, but our gamma feed filters those out (active=true), so without
+    // this sweep the row's `active` flag stays true forever. Skipping when the
+    // scan returned zero so an upstream outage does not deactivate everything.
+    if total_scanned > 0 {
+        if let Err(e) = deactivate_stale_polymarket(state).await {
+            warn!("Scanner: deactivate-stale failed: {}", e);
+        }
+    }
+
     record_scan_run(
         state,
         total_scanned as i32,
@@ -568,6 +578,26 @@ pub async fn run_scan(state: &AppState) -> Result<Vec<ScannedOpportunity>, Strin
     .await;
 
     Ok(all_opportunities)
+}
+
+/// Mark rows whose `last_scanned_at` is older than five missed ticks
+/// (~5 minutes at the default 60s interval) as inactive. The slug resolver,
+/// volume_spike_alert, and `/top` all read `WHERE active = true`; this keeps
+/// settled markets from leaking into those reads.
+async fn deactivate_stale_polymarket(state: &AppState) -> Result<u64, sqlx::Error> {
+    let result = sqlx::query(
+        "UPDATE polymarket_scanned_markets \
+         SET active = false \
+         WHERE active = true \
+           AND last_scanned_at < NOW() - INTERVAL '5 minutes'",
+    )
+    .execute(state.db.pool())
+    .await?;
+    let rows = result.rows_affected();
+    if rows > 0 {
+        info!("Scanner: deactivated {} stale polymarket rows", rows);
+    }
+    Ok(rows)
 }
 
 #[derive(Debug, Default, Clone, Copy)]


### PR DESCRIPTION
## Summary

Audit follow-up to #133. The slug-resolver fix made stale digest links
resolve again, but the deeper question — *why is the bot generating
links to settled markets in the first place?* — points at this:

- Polymarket and Limitless scanners use \`active=true\` filters when
  hitting their respective feeds, so settled markets stop appearing.
- Our \`polymarket_scanned_markets\` / \`limitless_scanned_markets\` tables
  are upserted on every hit but **never flipped back to \`active=false\`**
  when the upstream stops returning a row.
- Downstream consumers all filter \`WHERE active = TRUE\`:
  \`volume_spike_alert\`, the \`/top\` command, related listings — so a
  settled market keeps showing up in their candidate pool and can emit
  fresh alerts for prices that no longer move.

After each scan tick that returned at least one market, this runs:

\`\`\`sql
UPDATE polymarket_scanned_markets
SET active = false
WHERE active = true
  AND last_scanned_at < NOW() - INTERVAL '5 minutes'
\`\`\`

(and the equivalent for Limitless). Five minutes is roughly five missed
60s ticks. The zero-result guard avoids deactivating the whole table
during a transient gamma/limitless outage.

## Test plan

- [x] \`cargo build -p relay44-backend\` — clean
- [x] \`cargo clippy -p relay44-backend --lib -- -D warnings\` — clean
- [ ] After deploy: confirm scanner logs include \"deactivated N stale rows\" lines once a settlement window passes
- [ ] After deploy: \`SELECT COUNT(*) FROM polymarket_scanned_markets WHERE active = TRUE AND last_scanned_at < NOW() - INTERVAL '10 minutes'\` should be 0