### PR TITLE
telegram: route new_market alerts through the bus

### DIFF
--- a/app/src/services/alert_bus.rs
+++ b/app/src/services/alert_bus.rs
@@ -21,6 +21,7 @@ const DEFAULT_CAPACITY: usize = 512;
 pub enum SignalKind {
     ProbabilityShift,
     VolumeSpike,
+    NewMarket,
 }
 
 impl SignalKind {
@@ -28,6 +29,7 @@ impl SignalKind {
         match self {
             SignalKind::ProbabilityShift => "probability_shift",
             SignalKind::VolumeSpike => "volume_spike",
+            SignalKind::NewMarket => "new_market",
         }
     }
 }

--- a/app/src/services/digest_scheduler.rs
+++ b/app/src/services/digest_scheduler.rs
@@ -302,6 +302,7 @@ fn kind_label(kind: &str) -> &'static str {
     match kind {
         "probability_shift" => "Probability shift",
         "volume_spike" => "Volume spike",
+        "new_market" => "New market",
         _ => "Signal",
     }
 }

--- a/app/src/services/new_market_alert.rs
+++ b/app/src/services/new_market_alert.rs
@@ -18,6 +18,7 @@ use std::time::{Duration, Instant};
 use chrono::{DateTime, Utc};
 use log::{info, warn};
 
+use super::alert_bus::{now_secs, Signal, SignalKind};
 use super::telegram_format::{
     format_alert_header, format_deep_link, format_metadata_row, html_escape, TelegramClient,
 };
@@ -45,6 +46,15 @@ pub fn spawn(state: Arc<AppState>) {
         return;
     };
 
+    // When the digest scheduler is on, route through the bus so chats can
+    // /subscribe new_market individually instead of flooding the env chat.
+    let digest_enabled = env_bool("DIGEST_ENABLED", false);
+    let direct_send_client = if digest_enabled {
+        None
+    } else {
+        Some(TelegramClient::new(bot_token, chat_id))
+    };
+
     let watchlist = parse_csv_lower(std::env::var("NEW_MARKET_WATCHLIST").unwrap_or_default());
     let categories = parse_csv_lower(std::env::var("NEW_MARKET_CATEGORIES").unwrap_or_default());
     let poll = Duration::from_secs(env_u64("NEW_MARKET_POLL_SECS", DEFAULT_POLL_SECS));
@@ -65,14 +75,13 @@ pub fn spawn(state: Arc<AppState>) {
     }
 
     info!(
-        "Starting new-market alerts (watchlist={:?}, categories={:?}, poll={}s, rate_limit={}/hr)",
+        "Starting new-market alerts (watchlist={:?}, categories={:?}, poll={}s, rate_limit={}/hr, digest={})",
         watchlist,
         categories,
         poll.as_secs(),
         rate_limit_per_hour,
+        digest_enabled,
     );
-
-    let tg = TelegramClient::new(bot_token, chat_id);
 
     tokio::spawn(async move {
         let mut cursor_poly: Option<DateTime<Utc>> = None;
@@ -91,7 +100,8 @@ pub fn spawn(state: Arc<AppState>) {
                 Ok(rows) => {
                     for r in rows.iter().take(MAX_ALERTS_PER_TICK) {
                         maybe_alert(
-                            &tg,
+                            &state,
+                            direct_send_client.as_ref(),
                             &watchlist,
                             &categories,
                             cooldown,
@@ -116,7 +126,8 @@ pub fn spawn(state: Arc<AppState>) {
                 Ok(rows) => {
                     for r in rows.iter().take(MAX_ALERTS_PER_TICK) {
                         maybe_alert(
-                            &tg,
+                            &state,
+                            direct_send_client.as_ref(),
                             &watchlist,
                             &categories,
                             cooldown,
@@ -263,7 +274,8 @@ async fn fetch_new_limitless(
 }
 
 async fn maybe_alert(
-    tg: &TelegramClient,
+    state: &AppState,
+    tg: Option<&TelegramClient>,
     watchlist: &[String],
     categories: &[String],
     cooldown: Duration,
@@ -293,10 +305,44 @@ async fn maybe_alert(
 
     last_alert.insert(cooldown_key, Instant::now());
 
-    let text = format_alert(m, &reason);
-    match tg.send(&text).await {
-        Ok(()) => sent_times.push_back(Instant::now()),
-        Err(e) => warn!("telegram send failed (new-market): {}", e),
+    if let Some(tg) = tg {
+        let text = format_alert(m, &reason);
+        match tg.send(&text).await {
+            Ok(()) => sent_times.push_back(Instant::now()),
+            Err(e) => warn!("telegram send failed (new-market): {}", e),
+        }
+    } else {
+        // Bus path: publish to AlertBus so the digest scheduler delivers per
+        // chat with each chat's /subscribe new_market preference applied.
+        let signal = build_signal(m, &reason);
+        state.alert_bus.publish(signal).await;
+        sent_times.push_back(Instant::now());
+    }
+}
+
+fn build_signal(m: &NewMarket, reason: &str) -> Signal {
+    let mut body = format!("match: <code>{}</code>", html_escape(reason));
+    let meta = format_metadata_row(m.liquidity_usd, m.volume_24h_usd, Some(&m.category));
+    if !meta.is_empty() {
+        body.push('\n');
+        body.push_str(&meta);
+    }
+    Signal {
+        kind: SignalKind::NewMarket,
+        venue: m.venue.to_string(),
+        market_key: m.slug.clone(),
+        slug: (!m.slug.is_empty()).then(|| m.slug.clone()),
+        question: m.question.clone(),
+        liquidity_usd: m.liquidity_usd,
+        volume_24h_usd: m.volume_24h_usd,
+        category: (!m.category.is_empty() && m.category != "unknown")
+            .then(|| m.category.clone()),
+        // For new-market signals there's no shift magnitude — score on
+        // liquidity primarily by giving a constant move_size of 1.0 so the
+        // ranker still uses sqrt(liquidity) and recency.
+        move_size: 1.0,
+        body,
+        timestamp_secs: now_secs(),
     }
 }
 

--- a/app/src/services/telegram_commands.rs
+++ b/app/src/services/telegram_commands.rs
@@ -406,7 +406,7 @@ fn help_text() -> String {
         "/cooldown &lt;secs&gt; — per-chat alert cooldown (60-3600)",
         "/quiet &lt;hours&gt; — snooze digest for this chat (0.25-168)",
         "/unquiet — cancel an active quiet window",
-        "/subscribe &lt;kind&gt; — subscribe to a signal kind (probability_shift, volume_spike)",
+        "/subscribe &lt;kind&gt; — subscribe to a signal kind (probability_shift, volume_spike, new_market)",
         "/unsubscribe &lt;kind&gt; — remove a signal kind",
         "/digest — on-demand: drain bus and send current top signals",
         "/quote &lt;slug&gt; &lt;outcome&gt; &lt;buy|sell&gt; [size] — DM-only: best-execution quote",

--- a/app/src/services/tg_chat_config.rs
+++ b/app/src/services/tg_chat_config.rs
@@ -29,7 +29,7 @@ const MAX_QUIET_HOURS: f32 = 168.0;
 
 /// Signal kinds a chat may subscribe to. Strings match
 /// `SignalKind::as_str()` in `alert_bus.rs`.
-pub const VALID_KINDS: &[&str] = &["probability_shift", "volume_spike"];
+pub const VALID_KINDS: &[&str] = &["probability_shift", "volume_spike", "new_market"];
 
 /// In-memory snapshot of a `tg_chat_config` row.
 #[derive(Debug, Clone, sqlx::FromRow)]
@@ -311,6 +311,7 @@ pub fn parse_kind_arg(raw: &str) -> Result<&'static str, String> {
     let normalized = match lower.as_str() {
         "probability_shift" | "probability" | "prob" | "shift" => "probability_shift",
         "volume_spike" | "volume" | "spike" => "volume_spike",
+        "new_market" | "new" | "newmarket" | "markets" => "new_market",
         _ => {
             return Err(format!(
                 "unknown kind '{}'. valid: {}",
@@ -809,7 +810,17 @@ mod tests {
         assert_eq!(parse_kind_arg("prob").unwrap(), "probability_shift");
         assert_eq!(parse_kind_arg("VOLUME").unwrap(), "volume_spike");
         assert_eq!(parse_kind_arg("volume_spike").unwrap(), "volume_spike");
+        assert_eq!(parse_kind_arg("new_market").unwrap(), "new_market");
+        assert_eq!(parse_kind_arg("new").unwrap(), "new_market");
+        assert_eq!(parse_kind_arg("newmarket").unwrap(), "new_market");
+        assert_eq!(parse_kind_arg("Markets").unwrap(), "new_market");
         assert!(parse_kind_arg("garbage").is_err());
+    }
+
+    #[test]
+    fn valid_kinds_includes_new_market() {
+        // Subscribers see the canonical list when /subscribe rejects an arg.
+        assert!(VALID_KINDS.contains(&"new_market"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The new-market alerter was disabled in production
(\`NEW_MARKET_ALERTS_ENABLED=false\`) because every match landed
directly in the env supergroup, which made the channel unusable on
launch days. This wires it into the same publish-to-\`AlertBus\` path
\`probability_alert\` and \`volume_spike_alert\` already take when
\`DIGEST_ENABLED=true\`, then exposes the new kind on the per-chat
\`/subscribe\` surface.

- \`alert_bus\`: \`SignalKind\` gains a \`NewMarket\` variant.
- \`tg_chat_config\`: \`VALID_KINDS\` includes \"new_market\" and
  \`parse_kind_arg\` accepts the canonical name plus the obvious aliases
  (\"new\", \"newmarket\", \"markets\").
- \`new_market_alert\`: \`DIGEST_ENABLED=true\` now skips the direct
  TelegramClient and publishes to \`state.alert_bus\`. A new
  \`build_signal\` helper packs the match reason + metadata row into the
  Signal body so the digest scheduler can render the row without
  reaching back for venue-specific data. Rate limit + cooldown still
  apply on the publish path so a launch wave is bounded.
- \`digest_scheduler\`: \`kind_label\` gains a \"New market\" entry.
- \`telegram_commands\`: \`/help\` advertises the third subscribable kind.

## Test plan

- [x] \`cargo test -p relay44-backend --lib new_market_alert\` — 9 passed
- [x] \`cargo test -p relay44-backend --lib tg_chat_config\` — 23 passed (2 new)
- [x] \`cargo test -p relay44-backend --lib alert_bus\` — 4 passed
- [x] \`cargo clippy -p relay44-backend --lib -- -D warnings\` — clean
- [ ] After deploy: flip \`NEW_MARKET_ALERTS_ENABLED=true\` on Render. Without per-chat \`/subscribe new_market\` rows, only the env chat receives launch alerts. Each subscribed silo can opt in.

## Notes

- Chats with no \`tg_chat_config\` row or empty \`subscribed_kinds\` keep today's behavior (all kinds), so the env chat continues to receive new-market signals once the alerter flag flips.
- The direct-send path is preserved for environments where \`DIGEST_ENABLED=false\` (e.g. local dev). Production uses the bus path.
- Rate limit \`NEW_MARKET_RATE_LIMIT_PER_HOUR\` still bounds publish volume; the per-chat threshold/mute filters in the digest run on top of that.