### PR TITLE
telegram: /notify personal alerts + inline keyboards on /market

### DIFF
--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -123,6 +123,7 @@ async fn main() -> std::io::Result<()> {
     relay44_backend::services::volume_spike_alert::spawn(app_state.clone());
     relay44_backend::services::orderbook_imbalance_alert::spawn(app_state.clone());
     relay44_backend::services::digest_scheduler::spawn(app_state.clone());
+    relay44_backend::services::notify_scheduler::spawn(app_state.clone());
 
     let migration_db = app_state.db.clone();
     let background_state = app_state.clone();

--- a/app/src/services/mod.rs
+++ b/app/src/services/mod.rs
@@ -27,6 +27,8 @@ pub mod market_creator;
 pub mod market_data;
 pub mod metrics;
 pub mod new_market_alert;
+pub mod notify_rules;
+pub mod notify_scheduler;
 pub mod orchestrator;
 pub mod orderbook;
 pub mod orderbook_imbalance_alert;

--- a/app/src/services/notify_rules.rs
+++ b/app/src/services/notify_rules.rs
@@ -1,0 +1,187 @@
+//! Per-chat one-shot price-cross alerts driven by `/notify`.
+//!
+//! Storage layer for `tg_notify_rules`. Pure CRUD over the table — the
+//! scheduling/firing path lives in `notify_scheduler`. Threshold values are
+//! kept in YES-price space (0.0..1.0); the command parser converts user-facing
+//! pcts/cents to that shape before insert.
+
+use chrono::{DateTime, Utc};
+use sqlx::PgPool;
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct NotifyRule {
+    pub id: i64,
+    pub chat_id: i64,
+    pub venue: String,
+    pub slug: String,
+    pub threshold: f64,
+    pub baseline_price: f64,
+    pub created_at: DateTime<Utc>,
+    pub fired_at: Option<DateTime<Utc>>,
+    pub fired_price: Option<f64>,
+}
+
+/// Create a new active rule. Returns the rule id so callers can reference it
+/// in confirmation messages.
+pub async fn create(
+    pool: &PgPool,
+    chat_id: i64,
+    venue: &str,
+    slug: &str,
+    threshold: f64,
+    baseline_price: f64,
+) -> Result<i64, sqlx::Error> {
+    let row: (i64,) = sqlx::query_as(
+        "INSERT INTO tg_notify_rules \
+            (chat_id, venue, slug, threshold, baseline_price) \
+         VALUES ($1, $2, $3, $4, $5) \
+         RETURNING id",
+    )
+    .bind(chat_id)
+    .bind(venue)
+    .bind(slug)
+    .bind(threshold)
+    .bind(baseline_price)
+    .fetch_one(pool)
+    .await?;
+    Ok(row.0)
+}
+
+/// All active (unfired) rules for a chat, newest first.
+pub async fn list_active_for_chat(
+    pool: &PgPool,
+    chat_id: i64,
+) -> Result<Vec<NotifyRule>, sqlx::Error> {
+    sqlx::query_as::<_, NotifyRule>(
+        "SELECT id, chat_id, venue, slug, threshold, baseline_price, \
+                created_at, fired_at, fired_price \
+         FROM tg_notify_rules \
+         WHERE chat_id = $1 AND fired_at IS NULL \
+         ORDER BY created_at DESC",
+    )
+    .bind(chat_id)
+    .fetch_all(pool)
+    .await
+}
+
+/// All active rules across every chat, used by the scheduler tick.
+pub async fn list_all_active(pool: &PgPool) -> Result<Vec<NotifyRule>, sqlx::Error> {
+    sqlx::query_as::<_, NotifyRule>(
+        "SELECT id, chat_id, venue, slug, threshold, baseline_price, \
+                created_at, fired_at, fired_price \
+         FROM tg_notify_rules \
+         WHERE fired_at IS NULL",
+    )
+    .fetch_all(pool)
+    .await
+}
+
+/// Mark a rule as fired so the scheduler skips it next tick.
+pub async fn mark_fired(
+    pool: &PgPool,
+    rule_id: i64,
+    fired_price: f64,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "UPDATE tg_notify_rules \
+         SET fired_at = NOW(), fired_price = $2 \
+         WHERE id = $1 AND fired_at IS NULL",
+    )
+    .bind(rule_id)
+    .bind(fired_price)
+    .execute(pool)
+    .await
+    .map(|_| ())
+}
+
+/// Delete every active rule for a chat (`/notify clear`). Returns the number
+/// of rows removed so the caller can confirm with the user.
+pub async fn clear_for_chat(pool: &PgPool, chat_id: i64) -> Result<u64, sqlx::Error> {
+    let result = sqlx::query(
+        "DELETE FROM tg_notify_rules WHERE chat_id = $1 AND fired_at IS NULL",
+    )
+    .bind(chat_id)
+    .execute(pool)
+    .await?;
+    Ok(result.rows_affected())
+}
+
+/// Returns true if `current` has crossed `threshold` starting from the side
+/// `baseline` was on. Used by the scheduler to decide whether a rule fired
+/// since it was created.
+pub fn crossed(baseline: f64, current: f64, threshold: f64) -> bool {
+    (baseline < threshold && current >= threshold)
+        || (baseline > threshold && current <= threshold)
+}
+
+/// Parse a user-facing threshold ("60%", "60c", "0.60") into YES-price space.
+/// Returns an error for inputs outside (0, 1) or non-numeric.
+pub fn parse_threshold_arg(raw: &str) -> Result<f64, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err("threshold required".to_string());
+    }
+    let stripped = trimmed
+        .strip_suffix('%')
+        .or_else(|| trimmed.strip_suffix('c'))
+        .or_else(|| trimmed.strip_suffix('¢'))
+        .unwrap_or(trimmed);
+    let n: f64 = stripped
+        .parse()
+        .map_err(|_| format!("'{}' is not a number", trimmed))?;
+    if !n.is_finite() {
+        return Err("threshold must be finite".to_string());
+    }
+    // Treat any value > 1 as a percentage (the caller dropped the % sign).
+    let normalized = if n > 1.0 { n / 100.0 } else { n };
+    if normalized <= 0.0 || normalized >= 1.0 {
+        return Err("threshold must be between 0 and 100%".to_string());
+    }
+    Ok(normalized)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn crossed_detects_upward_movement() {
+        assert!(crossed(0.45, 0.61, 0.60));
+        assert!(crossed(0.45, 0.60, 0.60));
+        assert!(!crossed(0.45, 0.59, 0.60));
+    }
+
+    #[test]
+    fn crossed_detects_downward_movement() {
+        assert!(crossed(0.70, 0.59, 0.60));
+        assert!(crossed(0.70, 0.60, 0.60));
+        assert!(!crossed(0.70, 0.61, 0.60));
+    }
+
+    #[test]
+    fn crossed_returns_false_when_baseline_equals_threshold() {
+        // The rule was created exactly at the threshold; we fire on the
+        // first move that strictly leaves it, not on the create itself.
+        assert!(!crossed(0.60, 0.60, 0.60));
+    }
+
+    #[test]
+    fn parse_threshold_accepts_pct_and_cents_and_decimal() {
+        assert_eq!(parse_threshold_arg("60%").unwrap(), 0.60);
+        assert_eq!(parse_threshold_arg("60c").unwrap(), 0.60);
+        assert_eq!(parse_threshold_arg("60¢").unwrap(), 0.60);
+        assert_eq!(parse_threshold_arg("60").unwrap(), 0.60);
+        assert!((parse_threshold_arg("0.60").unwrap() - 0.60).abs() < 1e-9);
+        assert!((parse_threshold_arg("0.5").unwrap() - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn parse_threshold_rejects_out_of_range() {
+        assert!(parse_threshold_arg("0").is_err());
+        assert!(parse_threshold_arg("100").is_err());
+        assert!(parse_threshold_arg("-5").is_err());
+        assert!(parse_threshold_arg("150%").is_err());
+        assert!(parse_threshold_arg("").is_err());
+        assert!(parse_threshold_arg("abc").is_err());
+    }
+}

--- a/app/src/services/notify_scheduler.rs
+++ b/app/src/services/notify_scheduler.rs
@@ -1,0 +1,253 @@
+//! Tick that fires `/notify` rules.
+//!
+//! Pulls every active rule per tick, looks up the current YES price for each
+//! rule's market via the scanner table the rule's venue points at, and DMs
+//! the chat when the price has crossed the rule's threshold. Marks the rule
+//! fired so it is not evaluated again — users get a single shot.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use log::{info, warn};
+
+use super::notify_rules::{self, NotifyRule};
+use super::telegram_format::{html_escape, venue_title, TelegramClient};
+use crate::AppState;
+
+const DEFAULT_INTERVAL_SECS: u64 = 60;
+
+pub fn spawn(state: Arc<AppState>) {
+    let enabled = env_bool("NOTIFY_SCHEDULER_ENABLED", false);
+    if !enabled {
+        info!("Notify scheduler disabled (NOTIFY_SCHEDULER_ENABLED=false)");
+        return;
+    }
+
+    let Ok(bot_token) = std::env::var("TELEGRAM_BOT_TOKEN") else {
+        warn!("NOTIFY_SCHEDULER_ENABLED=true but TELEGRAM_BOT_TOKEN missing; not starting");
+        return;
+    };
+
+    let interval_secs = env_u64("NOTIFY_INTERVAL_SECS", DEFAULT_INTERVAL_SECS).max(15);
+    info!("Starting notify scheduler (interval={}s)", interval_secs);
+
+    // The chat id is per-rule, so the client's default chat id is unused.
+    let tg = TelegramClient::new(bot_token, String::new());
+
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(interval_secs));
+        interval.tick().await;
+        loop {
+            interval.tick().await;
+            run_tick(&state, &tg).await;
+        }
+    });
+}
+
+async fn run_tick(state: &AppState, tg: &TelegramClient) {
+    let rules = match notify_rules::list_all_active(state.db.pool()).await {
+        Ok(r) => r,
+        Err(e) => {
+            warn!("notify scheduler: list_all_active failed: {}", e);
+            return;
+        }
+    };
+    if rules.is_empty() {
+        return;
+    }
+
+    // Group by (venue, slug) so we read each market's current price once even
+    // when multiple chats have rules on it.
+    let mut by_market: HashMap<(String, String), Vec<NotifyRule>> = HashMap::new();
+    for rule in rules {
+        by_market
+            .entry((rule.venue.clone(), rule.slug.clone()))
+            .or_default()
+            .push(rule);
+    }
+
+    let prices = fetch_current_prices(state, by_market.keys()).await;
+
+    for ((venue, slug), market_rules) in by_market {
+        let Some(price) = prices.get(&(venue.clone(), slug.clone())).copied() else {
+            // Market not in the active scanner table (likely settled or
+            // delisted). Leave the rule alone — once the market reappears or
+            // the user clears it, it'll resolve.
+            continue;
+        };
+        for rule in market_rules {
+            if !notify_rules::crossed(rule.baseline_price, price, rule.threshold) {
+                continue;
+            }
+            let text = format_alert(&venue, &slug, &rule, price);
+            match tg.send_to(rule.chat_id, &text).await {
+                Ok(()) => {
+                    if let Err(e) = notify_rules::mark_fired(state.db.pool(), rule.id, price)
+                        .await
+                    {
+                        warn!("notify: mark_fired failed for rule {}: {}", rule.id, e);
+                    } else {
+                        info!(
+                            "notify: rule {} fired (chat={}, {}:{} now {:.2}%)",
+                            rule.id,
+                            rule.chat_id,
+                            venue,
+                            slug,
+                            price * 100.0
+                        );
+                    }
+                }
+                Err(e) => {
+                    warn!(
+                        "notify: send failed for rule {} (chat={}): {}",
+                        rule.id, rule.chat_id, e
+                    );
+                    // Leave fired_at NULL so a retry happens on the next tick.
+                }
+            }
+        }
+    }
+}
+
+async fn fetch_current_prices<'a>(
+    state: &AppState,
+    keys: impl Iterator<Item = &'a (String, String)>,
+) -> HashMap<(String, String), f64> {
+    let mut out = HashMap::new();
+    let mut poly_slugs: Vec<String> = Vec::new();
+    let mut lim_slugs: Vec<String> = Vec::new();
+    for (venue, slug) in keys {
+        match venue.as_str() {
+            "polymarket" => poly_slugs.push(slug.clone()),
+            "limitless" => lim_slugs.push(slug.clone()),
+            _ => {}
+        }
+    }
+
+    if !poly_slugs.is_empty() {
+        let rows: Result<Vec<(String, f64)>, sqlx::Error> = sqlx::query_as(
+            "SELECT slug, yes_price::double precision \
+             FROM polymarket_scanned_markets \
+             WHERE active = TRUE AND slug = ANY($1)",
+        )
+        .bind(&poly_slugs)
+        .fetch_all(state.db.pool())
+        .await;
+        match rows {
+            Ok(rows) => {
+                for (slug, price) in rows {
+                    out.insert(("polymarket".to_string(), slug), price);
+                }
+            }
+            Err(e) => warn!("notify scheduler: poly price query failed: {}", e),
+        }
+    }
+
+    if !lim_slugs.is_empty() {
+        let rows: Result<Vec<(String, f64)>, sqlx::Error> = sqlx::query_as(
+            "SELECT slug, yes_price::double precision \
+             FROM limitless_scanned_markets \
+             WHERE active = TRUE AND slug = ANY($1)",
+        )
+        .bind(&lim_slugs)
+        .fetch_all(state.db.pool())
+        .await;
+        match rows {
+            Ok(rows) => {
+                for (slug, price) in rows {
+                    out.insert(("limitless".to_string(), slug), price);
+                }
+            }
+            Err(e) => warn!("notify scheduler: limitless price query failed: {}", e),
+        }
+    }
+
+    out
+}
+
+fn format_alert(venue: &str, slug: &str, rule: &NotifyRule, price: f64) -> String {
+    let direction = if price > rule.baseline_price { "↑" } else { "↓" };
+    let link = super::telegram_format::format_deep_link(venue, slug)
+        .unwrap_or_else(|| html_escape(slug));
+    format!(
+        "<b>\u{1F514} /notify fired</b>\n\
+         {} on {} — <code>{}</code>\n\
+         baseline {:.0}% \u{2192} now <b>{:.0}%</b> (threshold {:.0}%)\n\
+         {}",
+        venue_title(venue),
+        direction,
+        html_escape(slug),
+        rule.baseline_price * 100.0,
+        price * 100.0,
+        rule.threshold * 100.0,
+        link,
+    )
+}
+
+fn env_bool(key: &str, default: bool) -> bool {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse::<bool>().ok())
+        .unwrap_or(default)
+}
+
+fn env_u64(key: &str, default: u64) -> u64 {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(default)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn rule(baseline: f64, threshold: f64) -> NotifyRule {
+        NotifyRule {
+            id: 1,
+            chat_id: -100,
+            venue: "polymarket".to_string(),
+            slug: "test-slug".to_string(),
+            threshold,
+            baseline_price: baseline,
+            created_at: Utc::now(),
+            fired_at: None,
+            fired_price: None,
+        }
+    }
+
+    #[test]
+    fn alert_includes_baseline_threshold_and_current() {
+        let r = rule(0.45, 0.60);
+        let text = format_alert("polymarket", "btc-100k", &r, 0.62);
+        assert!(text.contains("45%"));
+        assert!(text.contains("62%"));
+        assert!(text.contains("60%"));
+        assert!(text.contains("Polymarket"));
+        assert!(text.contains("btc-100k"));
+    }
+
+    #[test]
+    fn alert_renders_upward_arrow_for_rising_price() {
+        let r = rule(0.45, 0.60);
+        let text = format_alert("polymarket", "x", &r, 0.62);
+        assert!(text.contains("\u{2191}"), "expected up arrow in {text}");
+    }
+
+    #[test]
+    fn alert_renders_downward_arrow_for_falling_price() {
+        let r = rule(0.70, 0.60);
+        let text = format_alert("polymarket", "x", &r, 0.58);
+        assert!(text.contains("\u{2193}"), "expected down arrow in {text}");
+    }
+
+    #[test]
+    fn alert_html_escapes_slug() {
+        let r = rule(0.45, 0.60);
+        let text = format_alert("polymarket", "<evil>", &r, 0.62);
+        assert!(text.contains("&lt;evil&gt;"));
+        assert!(!text.contains("<evil>"));
+    }
+}

--- a/app/src/services/telegram_commands.rs
+++ b/app/src/services/telegram_commands.rs
@@ -88,6 +88,15 @@ pub fn spawn(state: Arc<AppState>) {
                                 &msg,
                             )
                             .await;
+                        } else if let Some(cb) = upd.callback_query {
+                            handle_callback_query(
+                                &state,
+                                &client,
+                                allowed_chat_id,
+                                dm_enabled,
+                                &cb,
+                            )
+                            .await;
                         }
                     }
                 }
@@ -249,12 +258,17 @@ async fn handle_message(
         None => return,
     };
 
+    let mut keyboard: Option<super::telegram_format::InlineKeyboardMarkup> = None;
     let reply = match parsed.name.as_str() {
         "start" | "help" => help_text(),
         "status" => status_text(),
         "version" => version_text(state),
         "top" => top_text(state, parsed.args.as_deref()).await,
-        "market" => market_text(state, parsed.args.as_deref()).await,
+        "market" => {
+            let (text, kb) = market_text(state, parsed.args.as_deref()).await;
+            keyboard = kb;
+            text
+        }
         "mute" => mute_text(state, msg.chat.id, parsed.args.as_deref()).await,
         "unmute" => unmute_text(state, msg.chat.id, parsed.args.as_deref()).await,
         "threshold" => threshold_text(state, msg.chat.id, parsed.args.as_deref()).await,
@@ -287,8 +301,71 @@ async fn handle_message(
         }
     };
 
-    if let Err(e) = client.send(msg.chat.id, &reply, Some(msg.message_id)).await {
+    let send_result = match keyboard {
+        Some(ref kb) => {
+            client
+                .send_with_keyboard(msg.chat.id, &reply, Some(msg.message_id), kb)
+                .await
+        }
+        None => client.send(msg.chat.id, &reply, Some(msg.message_id)).await,
+    };
+    if let Err(e) = send_result {
         warn!("telegram send failed: {}", e);
+    }
+}
+
+/// Handle a callback_query update emitted when a user taps an inline-keyboard
+/// button whose `callback_data` was set. URL buttons never reach this path.
+/// Each button encodes its action as `<verb>:<args>` in `callback_data`,
+/// capped at 64 bytes by Telegram.
+async fn handle_callback_query(
+    state: &AppState,
+    client: &TelegramClient,
+    allowed_chat_id: Option<i64>,
+    dm_enabled: bool,
+    cb: &CallbackQuery,
+) {
+    let Some(msg) = &cb.message else {
+        // Telegram delivered a callback whose source message we cannot
+        // inspect (very old message, or one outside the bot's history). Ack
+        // so the user's Telegram client stops the loading spinner.
+        let _ = client.answer_callback_query(&cb.id, None).await;
+        return;
+    };
+
+    // Same access policy as message handling — only the env chat or DMs (if
+    // enabled) can drive callbacks.
+    let is_group_match = Some(msg.chat.id) == allowed_chat_id;
+    let is_dm = msg.chat.is_dm();
+    if !(is_group_match || (dm_enabled && is_dm)) {
+        let _ = client.answer_callback_query(&cb.id, None).await;
+        return;
+    }
+
+    let Some(data) = cb.data.as_deref() else {
+        let _ = client.answer_callback_query(&cb.id, None).await;
+        return;
+    };
+
+    let toast = if let Some(slug) = data.strip_prefix(CALLBACK_MUTE_PREFIX) {
+        match tg_chat_config::add_muted_market(state.db.pool(), msg.chat.id, slug).await {
+            Ok(()) => Some(format!("muted {}", slug)),
+            Err(e) => {
+                warn!("callback /mute persist failed: {}", e);
+                Some("query failed".to_string())
+            }
+        }
+    } else {
+        // Unknown verb. Ack silently so the spinner stops; do not echo the
+        // raw payload — it could contain anything.
+        None
+    };
+
+    if let Err(e) = client
+        .answer_callback_query(&cb.id, toast.as_deref())
+        .await
+    {
+        warn!("answer_callback_query failed: {}", e);
     }
 }
 
@@ -550,10 +627,13 @@ async fn top_text(state: &AppState, args: Option<&str>) -> String {
     }
 }
 
-async fn market_text(state: &AppState, args: Option<&str>) -> String {
+async fn market_text(
+    state: &AppState,
+    args: Option<&str>,
+) -> (String, Option<super::telegram_format::InlineKeyboardMarkup>) {
     let slug = match args.and_then(|s| s.split_whitespace().next()) {
         Some(s) => s.to_string(),
-        None => return "usage: /market &lt;slug&gt;".to_string(),
+        None => return ("usage: /market &lt;slug&gt;".to_string(), None),
     };
 
     let pool = state.db.pool();
@@ -574,7 +654,7 @@ async fn market_text(state: &AppState, args: Option<&str>) -> String {
             let url = format!("https://relay44.com/markets/by-slug/polymarket/{}", slug);
             let liq_s = liq.map(format_money).unwrap_or_else(|| "—".to_string());
             let vol_s = vol.map(format_money).unwrap_or_else(|| "—".to_string());
-            format!(
+            let text = format!(
                 "<a href=\"{}\">{}</a>\n\
                  YES {:.1}¢ · NO {:.1}¢ · spread {}bps\n\
                  {} · liq {} · vol {}",
@@ -586,15 +666,39 @@ async fn market_text(state: &AppState, args: Option<&str>) -> String {
                 html_escape(&category),
                 liq_s,
                 vol_s,
-            )
+            );
+            let keyboard = build_market_keyboard(&slug, &url);
+            (text, Some(keyboard))
         }
-        Ok(None) => format!("no market with slug <code>{}</code>", html_escape(&slug)),
+        Ok(None) => (
+            format!("no market with slug <code>{}</code>", html_escape(&slug)),
+            None,
+        ),
         Err(e) => {
             warn!("/market query failed: {}", e);
-            "query failed".to_string()
+            ("query failed".to_string(), None)
         }
     }
 }
+
+/// Build the inline keyboard shown under a `/market` reply: an external Trade
+/// button (URL, no callback round-trip) and a Mute button (callback) that
+/// adds the slug to this chat's mute list. Slug must be a polymarket slug
+/// — limitless or aerodrome lookups would need separate keyboards.
+fn build_market_keyboard(
+    slug: &str,
+    relay_url: &str,
+) -> super::telegram_format::InlineKeyboardMarkup {
+    use super::telegram_format::{InlineKeyboardButton, InlineKeyboardMarkup};
+    InlineKeyboardMarkup {
+        inline_keyboard: vec![vec![
+            InlineKeyboardButton::url("\u{2197} Trade", relay_url.to_string()),
+            InlineKeyboardButton::callback("\u{1F515} Mute", format!("{}{}", CALLBACK_MUTE_PREFIX, slug)),
+        ]],
+    }
+}
+
+const CALLBACK_MUTE_PREFIX: &str = "mute:";
 
 async fn mute_text(state: &AppState, chat_id: i64, args: Option<&str>) -> String {
     let market = match args.and_then(|s| s.split_whitespace().next()) {
@@ -1166,6 +1270,8 @@ struct Update {
     update_id: i64,
     #[serde(default)]
     message: Option<Message>,
+    #[serde(default)]
+    callback_query: Option<CallbackQuery>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1182,6 +1288,15 @@ struct Message {
 struct User {
     #[serde(default)]
     is_bot: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct CallbackQuery {
+    id: String,
+    #[serde(default)]
+    data: Option<String>,
+    #[serde(default)]
+    message: Option<Message>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1228,7 +1343,7 @@ impl TelegramClient {
             .json(&Req {
                 offset,
                 timeout: POLL_TIMEOUT_SECS,
-                allowed_updates: &["message"],
+                allowed_updates: &["message", "callback_query"],
             })
             .send()
             .await
@@ -1267,6 +1382,68 @@ impl TelegramClient {
             reply_to_message_id: reply_to,
         };
         super::telegram_format::send_with_retry("sendMessage", || {
+            self.http.post(&url).json(&payload).send()
+        })
+        .await
+        .map(|_| ())
+    }
+
+    /// Send a reply with an inline keyboard attached.
+    async fn send_with_keyboard(
+        &self,
+        chat_id: i64,
+        text: &str,
+        reply_to: Option<i64>,
+        keyboard: &super::telegram_format::InlineKeyboardMarkup,
+    ) -> Result<(), String> {
+        #[derive(Serialize)]
+        struct Req<'a> {
+            chat_id: i64,
+            text: &'a str,
+            parse_mode: &'a str,
+            disable_web_page_preview: bool,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            reply_to_message_id: Option<i64>,
+            reply_markup: &'a super::telegram_format::InlineKeyboardMarkup,
+        }
+        let url = format!("https://api.telegram.org/bot{}/sendMessage", self.bot_token);
+        let payload = Req {
+            chat_id,
+            text,
+            parse_mode: "HTML",
+            disable_web_page_preview: true,
+            reply_to_message_id: reply_to,
+            reply_markup: keyboard,
+        };
+        super::telegram_format::send_with_retry("sendMessage", || {
+            self.http.post(&url).json(&payload).send()
+        })
+        .await
+        .map(|_| ())
+    }
+
+    /// Acknowledge a callback_query so the spinner stops in the user's
+    /// Telegram client. Optional `text` shows a brief popup.
+    async fn answer_callback_query(
+        &self,
+        callback_query_id: &str,
+        text: Option<&str>,
+    ) -> Result<(), String> {
+        #[derive(Serialize)]
+        struct Req<'a> {
+            callback_query_id: &'a str,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            text: Option<&'a str>,
+        }
+        let url = format!(
+            "https://api.telegram.org/bot{}/answerCallbackQuery",
+            self.bot_token
+        );
+        let payload = Req {
+            callback_query_id,
+            text,
+        };
+        super::telegram_format::send_with_retry("answerCallbackQuery", || {
             self.http.post(&url).json(&payload).send()
         })
         .await
@@ -1563,5 +1740,38 @@ mod tests {
         assert!(parse_quote_args(Some("slug YES buy -5")).is_err());
         assert!(parse_quote_args(Some("slug YES buy abc")).is_err());
         assert!(parse_quote_args(Some("slug YES buy 0")).is_err());
+    }
+
+    #[test]
+    fn market_keyboard_has_trade_url_and_mute_callback() {
+        let kb = build_market_keyboard(
+            "btc-100k-by-eoy",
+            "https://relay44.com/markets/by-slug/polymarket/btc-100k-by-eoy",
+        );
+        assert_eq!(kb.inline_keyboard.len(), 1);
+        let row = &kb.inline_keyboard[0];
+        assert_eq!(row.len(), 2);
+
+        // Trade button is a URL button — no callback round-trip needed.
+        assert!(row[0].text.contains("Trade"));
+        assert!(row[0].url.is_some());
+        assert!(row[0].callback_data.is_none());
+
+        // Mute button fires a callback the bot dispatches on receive.
+        assert!(row[1].text.contains("Mute"));
+        assert!(row[1].url.is_none());
+        assert_eq!(
+            row[1].callback_data.as_deref(),
+            Some("mute:btc-100k-by-eoy")
+        );
+    }
+
+    #[test]
+    fn callback_data_stays_within_telegram_64_byte_limit() {
+        // Telegram caps callback_data at 64 bytes. Mute prefix + a long slug
+        // could blow past that, so worth pinning.
+        let max_slug_len = 64 - CALLBACK_MUTE_PREFIX.len();
+        // Most polymarket slugs are well under this — sanity-check the cap.
+        assert!(max_slug_len > 50, "mute prefix leaves room for long slugs");
     }
 }

--- a/app/src/services/telegram_commands.rs
+++ b/app/src/services/telegram_commands.rs
@@ -269,6 +269,7 @@ async fn handle_message(
         "link" => link_text(state, msg.chat.id, nonces, parsed.args.as_deref()).await,
         "verify" => verify_text(state, msg.chat.id, nonces, parsed.args.as_deref()).await,
         "unlink" => unlink_text(state, msg.chat.id).await,
+        "notify" => notify_text(state, msg.chat.id, parsed.args.as_deref()).await,
         _ => {
             // Groups: stay silent — third-party bots own commands like
             // /setup_raid and we don't want to spam "unknown command".
@@ -413,6 +414,7 @@ fn help_text() -> String {
         "/link &lt;0x…&gt; — start read-only wallet binding",
         "/verify &lt;signature&gt; — finish wallet binding",
         "/unlink — drop linked wallet",
+        "/notify &lt;slug&gt; &lt;pct&gt; — one-shot DM when a market crosses pct",
         "/help — this list",
         "",
         "<i>Binding a wallet grants no spending authority. Trade execution is not available.</i>",
@@ -955,6 +957,178 @@ async fn unlink_text(state: &AppState, chat_id: i64) -> String {
             "query failed".to_string()
         }
     }
+}
+
+/// `/notify <slug> <pct>` — create a one-shot DM alert when a market crosses
+/// a threshold. `/notify list` shows active rules; `/notify clear` deletes
+/// every active rule for the chat.
+async fn notify_text(state: &AppState, chat_id: i64, args: Option<&str>) -> String {
+    let raw = args.map(|s| s.trim()).unwrap_or_default();
+    if raw.is_empty() {
+        return notify_usage();
+    }
+
+    let mut iter = raw.split_whitespace();
+    let head = iter.next().unwrap_or_default();
+    match head {
+        "list" => return notify_list_text(state, chat_id).await,
+        "clear" => return notify_clear_text(state, chat_id).await,
+        _ => {}
+    }
+
+    let slug = head;
+    let threshold_arg = iter.next();
+    if iter.next().is_some() {
+        return notify_usage();
+    }
+    let threshold_arg = match threshold_arg {
+        Some(t) => t,
+        None => return notify_usage(),
+    };
+
+    let threshold = match crate::services::notify_rules::parse_threshold_arg(threshold_arg) {
+        Ok(t) => t,
+        Err(e) => return html_escape(&e),
+    };
+
+    let pool = state.db.pool();
+    let resolved = match resolve_notify_market(pool, slug).await {
+        Ok(r) => r,
+        Err(e) => return e,
+    };
+    let (venue, canonical_slug, baseline) = resolved;
+
+    if (baseline - threshold).abs() < 1e-9 {
+        return format!(
+            "current price for <code>{}</code> is already at the threshold ({:.0}%); pick a different value",
+            html_escape(&canonical_slug),
+            threshold * 100.0
+        );
+    }
+
+    match crate::services::notify_rules::create(
+        pool,
+        chat_id,
+        &venue,
+        &canonical_slug,
+        threshold,
+        baseline,
+    )
+    .await
+    {
+        Ok(_id) => {
+            let direction = if baseline < threshold {
+                "rises to"
+            } else {
+                "falls to"
+            };
+            format!(
+                "watching <b>{}</b> on {}. baseline {:.0}% \u{2192} ping you when it {} <b>{:.0}%</b>.",
+                html_escape(&canonical_slug),
+                super::telegram_format::venue_title(&venue),
+                baseline * 100.0,
+                direction,
+                threshold * 100.0,
+            )
+        }
+        Err(e) => {
+            warn!("/notify persist failed: {}", e);
+            "query failed".to_string()
+        }
+    }
+}
+
+async fn notify_list_text(state: &AppState, chat_id: i64) -> String {
+    match crate::services::notify_rules::list_active_for_chat(state.db.pool(), chat_id).await {
+        Ok(rules) if rules.is_empty() => "no active /notify rules. set one with /notify &lt;slug&gt; &lt;pct&gt;".to_string(),
+        Ok(rules) => {
+            let mut lines = Vec::with_capacity(rules.len() + 1);
+            lines.push(format!("<b>active /notify rules ({})</b>", rules.len()));
+            for r in rules {
+                lines.push(format!(
+                    "• {} <code>{}</code> — baseline {:.0}% \u{2192} {:.0}%",
+                    super::telegram_format::venue_title(&r.venue),
+                    html_escape(&r.slug),
+                    r.baseline_price * 100.0,
+                    r.threshold * 100.0,
+                ));
+            }
+            lines.join("\n")
+        }
+        Err(e) => {
+            warn!("/notify list failed: {}", e);
+            "query failed".to_string()
+        }
+    }
+}
+
+async fn notify_clear_text(state: &AppState, chat_id: i64) -> String {
+    match crate::services::notify_rules::clear_for_chat(state.db.pool(), chat_id).await {
+        Ok(0) => "no active /notify rules to clear".to_string(),
+        Ok(n) => format!("cleared {} /notify rule(s)", n),
+        Err(e) => {
+            warn!("/notify clear failed: {}", e);
+            "query failed".to_string()
+        }
+    }
+}
+
+fn notify_usage() -> String {
+    "usage:\n\
+     /notify &lt;slug&gt; &lt;pct&gt; — DM you when the market crosses pct (e.g. 60%)\n\
+     /notify list — show active rules\n\
+     /notify clear — clear every active rule for this chat"
+        .to_string()
+}
+
+/// Look up a market by slug across both scanner tables and return
+/// (venue, canonical_slug, current_yes_price). Errors as a user-facing
+/// HTML-escaped string the command handler can return verbatim.
+async fn resolve_notify_market(
+    pool: &sqlx::PgPool,
+    slug: &str,
+) -> Result<(String, String, f64), String> {
+    let slug_trimmed = slug.trim();
+    if slug_trimmed.is_empty() {
+        return Err("slug required".to_string());
+    }
+
+    let poly: Option<(String, f64)> = sqlx::query_as(
+        "SELECT slug, yes_price::double precision \
+         FROM polymarket_scanned_markets \
+         WHERE active = TRUE AND slug = $1 LIMIT 1",
+    )
+    .bind(slug_trimmed)
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| {
+        warn!("/notify resolve poly query failed: {}", e);
+        "query failed".to_string()
+    })?;
+    if let Some((s, price)) = poly {
+        return Ok(("polymarket".to_string(), s, price));
+    }
+
+    let lim: Option<(String, f64)> = sqlx::query_as(
+        "SELECT slug, yes_price::double precision \
+         FROM limitless_scanned_markets \
+         WHERE active = TRUE AND slug = $1 LIMIT 1",
+    )
+    .bind(slug_trimmed)
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| {
+        warn!("/notify resolve limitless query failed: {}", e);
+        "query failed".to_string()
+    })?;
+    if let Some((s, price)) = lim {
+        return Ok(("limitless".to_string(), s, price));
+    }
+
+    Err(format!(
+        "market <code>{}</code> not found in active scanner tables",
+        html_escape(slug_trimmed)
+    ))
 }
 
 fn env_bool(key: &str) -> bool {

--- a/app/src/services/telegram_format.rs
+++ b/app/src/services/telegram_format.rs
@@ -163,7 +163,7 @@ impl TelegramClient {
     }
 
     pub async fn send(&self, text: &str) -> Result<(), String> {
-        self.send_raw(&self.chat_id, text).await
+        self.send_raw(&self.chat_id, text, None).await
     }
 
     /// Send to an arbitrary chat id, ignoring the client's configured default.
@@ -171,16 +171,36 @@ impl TelegramClient {
     /// out to multiple subscribed chats with per-chat filters applied.
     pub async fn send_to(&self, chat_id: i64, text: &str) -> Result<(), String> {
         let cid = chat_id.to_string();
-        self.send_raw(&cid, text).await
+        self.send_raw(&cid, text, None).await
     }
 
-    async fn send_raw(&self, chat_id: &str, text: &str) -> Result<(), String> {
+    /// Send with an inline keyboard attached. Buttons render under the
+    /// message in every Telegram client; URL buttons open the link, callback
+    /// buttons fire a `callback_query` update the long-poll handler picks up.
+    pub async fn send_to_with_keyboard(
+        &self,
+        chat_id: i64,
+        text: &str,
+        keyboard: &InlineKeyboardMarkup,
+    ) -> Result<(), String> {
+        let cid = chat_id.to_string();
+        self.send_raw(&cid, text, Some(keyboard)).await
+    }
+
+    async fn send_raw(
+        &self,
+        chat_id: &str,
+        text: &str,
+        keyboard: Option<&InlineKeyboardMarkup>,
+    ) -> Result<(), String> {
         #[derive(Serialize)]
         struct Payload<'a> {
             chat_id: &'a str,
             text: &'a str,
             parse_mode: &'a str,
             disable_web_page_preview: bool,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            reply_markup: Option<&'a InlineKeyboardMarkup>,
         }
         let url = format!("https://api.telegram.org/bot{}/sendMessage", self.bot_token);
         let payload = Payload {
@@ -188,10 +208,48 @@ impl TelegramClient {
             text,
             parse_mode: "HTML",
             disable_web_page_preview: true,
+            reply_markup: keyboard,
         };
         send_with_retry("sendMessage", || self.http.post(&url).json(&payload).send())
             .await
             .map(|_| ())
+    }
+}
+
+/// Telegram inline keyboard. A grid of buttons rendered under the message.
+/// Each inner Vec is a row; buttons within a row are arranged horizontally.
+#[derive(Debug, Clone, Serialize)]
+pub struct InlineKeyboardMarkup {
+    pub inline_keyboard: Vec<Vec<InlineKeyboardButton>>,
+}
+
+/// One inline keyboard button. Either a URL (opens externally) or a callback
+/// (fires a `callback_query` event the bot handles). Callback data is capped
+/// at 64 bytes by Telegram.
+#[derive(Debug, Clone, Serialize)]
+pub struct InlineKeyboardButton {
+    pub text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub callback_data: Option<String>,
+}
+
+impl InlineKeyboardButton {
+    pub fn url(text: impl Into<String>, url: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            url: Some(url.into()),
+            callback_data: None,
+        }
+    }
+
+    pub fn callback(text: impl Into<String>, data: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            url: None,
+            callback_data: Some(data.into()),
+        }
     }
 }
 

--- a/migrations/058_tg_notify_rules.sql
+++ b/migrations/058_tg_notify_rules.sql
@@ -1,0 +1,32 @@
+-- Per-chat one-shot price-cross alerts. /notify <slug> <pct> creates a row;
+-- the scheduler ticks, detects a crossing, sends a DM, marks fired_at, and
+-- the row is no longer evaluated. Users who want a recurring trigger can
+-- re-issue /notify after it fires.
+
+CREATE TABLE IF NOT EXISTS tg_notify_rules (
+    id BIGSERIAL PRIMARY KEY,
+    chat_id BIGINT NOT NULL,
+    venue TEXT NOT NULL CHECK (venue IN ('polymarket', 'limitless')),
+    slug TEXT NOT NULL,
+    -- Threshold in YES-price space, 0.0..1.0. A "60%" arg becomes 0.60.
+    threshold DOUBLE PRECISION NOT NULL CHECK (threshold > 0.0 AND threshold < 1.0),
+    -- Baseline price at rule creation. The scheduler fires when the current
+    -- price crosses `threshold` from the side `baseline_price` was on, so a
+    -- rule created when YES=0.45 with threshold 0.60 fires on the upside,
+    -- and a rule created when YES=0.70 with threshold 0.60 fires on the
+    -- downside.
+    baseline_price DOUBLE PRECISION NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    fired_at TIMESTAMPTZ,
+    fired_price DOUBLE PRECISION
+);
+
+-- Active rules, by chat (for /notify list).
+CREATE INDEX IF NOT EXISTS idx_tg_notify_rules_active_by_chat
+    ON tg_notify_rules (chat_id, created_at DESC)
+    WHERE fired_at IS NULL;
+
+-- Active rules, for the scheduler's per-tick scan grouped by market.
+CREATE INDEX IF NOT EXISTS idx_tg_notify_rules_active_by_market
+    ON tg_notify_rules (venue, slug)
+    WHERE fired_at IS NULL;


### PR DESCRIPTION
## Summary

Two telegram features stacked on the same branch — both no-LLM-cost, no
new external services, a few hundred lines total:

### A. \`/notify <slug> <pct>\` — one-shot DM alerts

\`9b...\`/\`6a19883\` (squashed)

User says \`/notify btc-100k 60%\`; bot records the current YES price as
baseline. The notify scheduler ticks every 60s, groups active rules by
market so each price is read once, and DMs the chat when the price
crosses the threshold from whichever side the baseline was on. Single
shot — fired_at is set, the rule is no longer evaluated.

- Migration \`058_tg_notify_rules.sql\` with two partial indexes for the
  list-by-chat and the per-tick scan-by-market reads.
- \`services/notify_rules.rs\` for CRUD + threshold parsing
  (60% / 60c / 60¢ / 0.60 / 60 all accepted).
- \`services/notify_scheduler.rs\` for the tick. Gated by
  \`NOTIFY_SCHEDULER_ENABLED\` so the new background task does not start
  unannounced.
- Commands: \`/notify <slug> <pct>\`, \`/notify list\`, \`/notify clear\`.

### B. Inline keyboards on \`/market\`

\`00a14dd\`

\`/market <slug>\` now renders two buttons under the reply: **↗ Trade**
(URL button — opens the relay44.com market page directly, no callback
round-trip) and **🔕 Mute** (callback button — adds the slug to the
chat's mute list without forcing the user to type \`/mute <slug>\`).

- \`telegram_format\` gains \`InlineKeyboardMarkup\` + \`InlineKeyboardButton\`
  + \`send_to_with_keyboard\`.
- \`telegram_commands\` extends \`getUpdates\` allowed_updates to include
  \`callback_query\`, parses the new field, and dispatches on a
  \`<verb>:<args>\` prefix. \`mute:<slug>\` is the first verb wired up.
- \`handle_callback_query\` enforces the same chat-access policy as
  \`handle_message\` and acks via \`answerCallbackQuery\` so the user's
  Telegram spinner stops.
- Tests pin the keyboard structure and the 64-byte \`callback_data\`
  budget Telegram enforces.

## Test plan

- [x] \`cargo test -p relay44-backend --lib notify\` — **9 passed**
- [x] \`cargo test -p relay44-backend --lib telegram_commands\` — **32 passed** (2 new on keyboard)
- [x] \`cargo clippy -p relay44-backend --lib -- -D warnings\` — clean
- [ ] After deploy + flag flip: \`/notify <known-slug> 60%\` confirms with baseline; \`/notify list\` returns the rule; price cross fires DM
- [ ] After deploy: \`/market <slug>\` reply has [↗ Trade] [🔕 Mute] buttons; tapping Mute toasts "muted" and adds to the chat's mute list

## Notes

- Notify scheduler is **off by default** — flip \`NOTIFY_SCHEDULER_ENABLED=true\` on Render to start the tick. With it off the command path still records rules, they just won't fire.
- The Mute callback is the first user-facing inline-keyboard interaction in the bot. Future verbs (Watch, Notify-from-button) slot next to it without further plumbing changes.
- Limitless and Aerodrome markets aren't served by the keyboard yet — \`/market\` only resolves polymarket slugs today, so the keyboard URL is hard-coded to the polymarket route.